### PR TITLE
Add no-windows-permissions feature, to disable access/owner checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,4 @@ serial_test = "0.5"
 
 [features]
 sudo = []
+no-windows-permissions = []

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -15,6 +15,13 @@ impl Owner {
     }
 }
 
+impl Default for Owner {
+    fn default() -> Owner
+    {
+        Owner { user: String::from(""), group: String::from("") }
+    }
+}
+
 #[cfg(unix)]
 impl<'a> From<&'a Metadata> for Owner {
     fn from(meta: &Metadata) -> Self {
@@ -37,10 +44,18 @@ impl<'a> From<&'a Metadata> for Owner {
 
 impl Owner {
     pub fn render_user(&self, colors: &Colors) -> ColoredString {
-        colors.colorize(self.user.clone(), &Elem::User)
+        if self.user.len() == 0 {
+            colors.colorize("?".to_owned(), &Elem::User)
+        } else {
+            colors.colorize(self.user.clone(), &Elem::User)
+        }
     }
 
     pub fn render_group(&self, colors: &Colors) -> ColoredString {
-        colors.colorize(self.group.clone(), &Elem::Group)
+        if self.group.len() == 0 {
+            colors.colorize("?".to_owned(), &Elem::Group)
+        } else {
+            colors.colorize(self.group.clone(), &Elem::Group)
+        }
     }
 }

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -103,6 +103,26 @@ impl Permissions {
     }
 }
 
+impl Default for Permissions
+{
+    fn default() -> Permissions {
+        Permissions {
+            user_read: false,
+            user_write: false,
+            user_execute: false,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: false,
+            setgid: false,
+            setuid: false
+        }
+    }
+}
+
 // More readable aliases for the permission bits exposed by libc.
 #[allow(trivial_numeric_casts)]
 #[cfg(unix)]

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -13,6 +13,32 @@ use super::{Owner, Permissions};
 
 const BUF_SIZE: u32 = 256;
 
+#[cfg(feature = "no-windows-permissions")]
+pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
+    let owner = Owner::new("?".to_string(), "?".to_string());
+
+    let permissions = Permissions {
+        user_read: true,
+        user_write: true,
+        user_execute: true,
+
+        group_read: true,
+        group_write: true,
+        group_execute: true,
+
+        other_read: true,
+        other_write: true,
+        other_execute: true,
+
+        sticky: false,
+        setuid: false,
+        setgid: false,
+    };
+
+    Ok((owner, permissions))
+}
+
+#[cfg(not(feature = "no-windows-permissions"))]
 pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
     // Overall design:
     // This function allocates some data with GetNamedSecurityInfoW,

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -18,13 +18,13 @@ pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
     let owner = Owner::new("?".to_string(), "?".to_string());
 
     let permissions = Permissions {
-        user_read: true,
-        user_write: true,
-        user_execute: true,
+        user_read: false,
+        user_write: false,
+        user_execute: false,
 
-        group_read: true,
-        group_write: true,
-        group_execute: true,
+        group_read: false,
+        group_write: false,
+        group_execute: false,
 
         other_read: true,
         other_write: true,

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -13,33 +13,7 @@ use super::{Owner, Permissions};
 
 const BUF_SIZE: u32 = 256;
 
-#[cfg(feature = "no-windows-permissions")]
-pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
-    let owner = Owner::new("?".to_string(), "?".to_string());
-
-    let permissions = Permissions {
-        user_read: false,
-        user_write: false,
-        user_execute: false,
-
-        group_read: false,
-        group_write: false,
-        group_execute: false,
-
-        other_read: true,
-        other_write: true,
-        other_execute: true,
-
-        sticky: false,
-        setuid: false,
-        setgid: false,
-    };
-
-    Ok((owner, permissions))
-}
-
-#[cfg(not(feature = "no-windows-permissions"))]
-pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
+pub fn get_file_data(path: &Path) -> Result<(Option<Owner>, Option<Permissions>), io::Error> {
     // Overall design:
     // This function allocates some data with GetNamedSecurityInfoW,
     // manipulates it only through WinAPI calls (treating the pointers as
@@ -194,7 +168,7 @@ pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
         winapi::um::winbase::LocalFree(sd_ptr);
     }
 
-    Ok((owner, permissions))
+    Ok((Some(owner), Some(permissions)))
 }
 
 /// Evaluate an ACL for a particular trustee and get its access rights


### PR DESCRIPTION
Doing this on Windows is very slow; this adds a feature flag to disable doing these checks, making lsd as fast as any other directory listing tool.  Without this, running `lsd` on a directory with ~100 files takes around 600ms.  With this feature enabled, it takes 40ms.

Adds a bunch of compilation warnings unfortunately; the structure could be better to clean this up.

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry