### PR TITLE
Extract a symlink's target type if possible, so it can have proper colors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added support for coloring symlink targets.
 - Added support for the MISSING / mi= dircolors variable for broken symlink targets.
 - Add support for theme from [zwpaper](https://github.com/zwpaper) [#452](https://github.com/Peltoche/lsd/pull/452)
 - Update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -1,17 +1,29 @@
 use crate::color::{ColoredString, Colors, Elem};
 use crate::flags::Flags;
+use crate::meta::{FileType, Permissions};
 use std::fs::read_link;
 use std::path::Path;
 
 #[derive(Clone, Debug)]
 pub struct SymLink {
     target: Option<String>,
+    target_type: Option<FileType>,
     valid: bool,
 }
 
 impl<'a> From<&'a Path> for SymLink {
     fn from(path: &'a Path) -> Self {
         if let Ok(target) = read_link(path) {
+            // Extract the symlink's target type if possible, so it can have proper colors.
+            let target_type = match target.metadata() {
+                Ok(metadata) => Some(FileType::new(
+                    &metadata,
+                    None,
+                    &Permissions::from(&metadata),
+                )),
+                Err(_) => None,
+            };
+
             if target.is_absolute() || path.parent() == None {
                 return Self {
                     valid: target.exists(),
@@ -21,6 +33,7 @@ impl<'a> From<&'a Path> for SymLink {
                             .expect("failed to convert symlink to str")
                             .to_string(),
                     ),
+                    target_type,
                 };
             }
 
@@ -31,12 +44,14 @@ impl<'a> From<&'a Path> for SymLink {
                         .expect("failed to convert symlink to str")
                         .to_string(),
                 ),
+                target_type,
                 valid: path.parent().unwrap().join(target).exists(),
             };
         }
 
         Self {
             target: None,
+            target_type: None,
             valid: false,
         }
     }
@@ -50,7 +65,20 @@ impl SymLink {
     pub fn render(&self, colors: &Colors, flag: &Flags) -> ColoredString {
         if let Some(target_string) = self.symlink_string() {
             let elem = if self.valid {
-                &Elem::SymLink
+                // Proper colors for symlink target file types.
+                match self.target_type {
+                    Some(FileType::BlockDevice) => &Elem::BlockDevice,
+                    Some(FileType::CharDevice) => &Elem::CharDevice,
+                    Some(FileType::Directory { uid: _ }) => &Elem::Dir { uid: false },
+                    Some(FileType::File { uid: _, exec: _ }) => &Elem::File {
+                        uid: false,
+                        exec: false,
+                    },
+                    Some(FileType::Pipe) => &Elem::Pipe,
+                    Some(FileType::Socket) => &Elem::Socket,
+                    Some(FileType::Special) => &Elem::Special,
+                    _ => &Elem::SymLink,
+                }
             } else {
                 &Elem::MissingSymLinkTarget
             };
@@ -79,11 +107,13 @@ mod tests {
     use crate::color::{Colors, ThemeOption};
     use crate::config_file::Config;
     use crate::flags::Flags;
+    use crate::meta::FileType;
 
     #[test]
     fn test_symlink_render_default_valid_target_nocolor() {
         let link = SymLink {
             target: Some("/target".to_string()),
+            target_type: None,
             valid: true,
         };
         let argv = vec!["lsd"];
@@ -102,6 +132,7 @@ mod tests {
     fn test_symlink_render_default_invalid_target_nocolor() {
         let link = SymLink {
             target: Some("/target".to_string()),
+            target_type: None,
             valid: false,
         };
         let argv = vec!["lsd"];
@@ -120,6 +151,7 @@ mod tests {
     fn test_symlink_render_default_invalid_target_withcolor() {
         let link = SymLink {
             target: Some("/target".to_string()),
+            target_type: Some(FileType::SymLink { is_dir: false }),
             valid: false,
         };
         let argv = vec!["lsd"];


### PR DESCRIPTION
<!--- PR Description --->
Extract a symlink's target type if possible, so it can have proper colors.

Before:
<img width="565" alt="CleanShot 2021-10-08 at 11 12 14@2x" src="https://user-images.githubusercontent.com/22371/136604007-087f14d9-a670-4458-ab05-26b9810efe3a.png">

After:

<img width="580" alt="CleanShot 2021-10-08 at 11 11 43@2x" src="https://user-images.githubusercontent.com/22371/136604028-175a7f31-56ca-4531-9a31-2d243393908c.png">

---

- [X] Use `cargo fmt`
- [X] Add necessary tests
- [X] Add changelog entry