### PR TITLE
Feature: Color override setting for file/directory indicator column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Added
 - Add icon for Zstandard from [nix6839](https://github.com/nix6839)
+- Add optional theme overrides for file indicator (`file-indicator`) and directory indicator (`directory-indicator`) in `--long` view from [themkat](https://github.com/themkat)
 ### Changed
 ### Fixed
 - Fix rendering issues in Windows from [meain](https://gitHub.com/meain)

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ links:
 tree-edge: 245
 ```
 
+There are also optional fields `file-indicator` and `directory-indicator` to change the colors of the file indicator `.` and  directory indicator `d` in the `--long` view. These default to the regular colors of the file names and directory names respectively. 
+
 When creating a theme for `lsd`, you can specify any part of the default theme,
 and then change its colors, the items missed would fallback to use the default colors.
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -29,6 +29,8 @@ pub enum Elem {
     Socket,
     Special,
 
+    DirectoryIndicator,
+
     /// Permission
     Read,
     Write,
@@ -99,6 +101,12 @@ impl Elem {
             Elem::CharDevice => theme.file_type.char_device,
             Elem::Socket => theme.file_type.socket,
             Elem::Special => theme.file_type.special,
+
+            // default to dir color (no uid) if no special color specified
+            Elem::DirectoryIndicator => match theme.directory_indicator {
+                Some(color) => color,
+                None => theme.file_type.dir.no_uid,
+            },
 
             Elem::Read => theme.permission.read,
             Elem::Write => theme.permission.write,
@@ -215,6 +223,13 @@ impl Colors {
                     Some("di")
                 }
             }
+            Elem::DirectoryIndicator => match &self.theme {
+                Some(theme) => match theme.directory_indicator {
+                    Some(_) => None,
+                    None => Some("di"),
+                },
+                None => None,
+            },
             Elem::SymLink => Some("ln"),
             Elem::Pipe => Some("pi"),
             Elem::Socket => Some("so"),
@@ -336,6 +351,7 @@ mod elem {
         Theme {
             user: Color::AnsiValue(230),  // Cornsilk1
             group: Color::AnsiValue(187), // LightYellow3
+            directory_indicator: Some(Color::AnsiValue(15)),
             permission: theme::Permission {
                 read: Color::Green,
                 write: Color::Yellow,
@@ -425,5 +441,9 @@ mod elem {
             .get_color(&test_theme()),
             Color::AnsiValue(184),
         );
+        assert_eq!(
+            Elem::DirectoryIndicator.get_color(&test_theme()),
+            Color::AnsiValue(15)
+        )
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -237,21 +237,17 @@ impl Colors {
                 } else {
                     Some("di")
                 }
-            },
+            }
             Elem::FileIndicator { exec } => {
-                let indicator_type = if *exec {
-                    "ex"
-                } else {
-                    "fi"
-                };
+                let indicator_type = if *exec { "ex" } else { "fi" };
                 match &self.theme {
                     Some(theme) => match theme.file_indicator {
                         Some(_) => None,
-                        None => Some(indicator_type)
+                        None => Some(indicator_type),
                     },
-                    None => Some(indicator_type)
+                    None => Some(indicator_type),
                 }
-            },
+            }
             Elem::DirectoryIndicator => match &self.theme {
                 Some(theme) => match theme.directory_indicator {
                     Some(_) => None,
@@ -472,9 +468,7 @@ mod elem {
             Color::AnsiValue(184),
         );
         assert_eq!(
-            Elem::FileIndicator {
-                exec: false
-            }.get_color(&test_theme()),
+            Elem::FileIndicator { exec: false }.get_color(&test_theme()),
             Color::AnsiValue(184)
         );
         assert_eq!(
@@ -492,9 +486,7 @@ mod elem {
         let mut theme = test_theme();
         theme.file_indicator = Some(Color::AnsiValue(15));
         assert_eq!(
-            Elem::FileIndicator {
-                exec: false
-            }.get_color(&theme),
+            Elem::FileIndicator { exec: false }.get_color(&theme),
             Color::AnsiValue(15)
         );
         assert_eq!(

--- a/src/color.rs
+++ b/src/color.rs
@@ -367,9 +367,10 @@ mod tests {
 
 #[cfg(test)]
 mod elem {
-    use super::Elem;
+    use super::{Colors, Elem};
     use crate::color::{theme, Theme};
     use crossterm::style::Color;
+    use lscolors::Indicator;
 
     #[cfg(test)]
     fn test_theme() -> Theme {
@@ -502,6 +503,29 @@ mod elem {
         assert_eq!(
             Elem::DirectoryIndicator.get_color(&theme),
             Color::AnsiValue(15)
+        );
+    }
+
+    // test the default behavior without x-indicator properties set
+    #[test]
+    fn test_file_indicator_lscolors_defaults() {
+        let colors = Colors::new(super::ThemeOption::Default);
+        assert_eq!(
+            colors.get_indicator_from_elem(&Elem::FileIndicator { exec: false }),
+            Indicator::from("fi")
+        );
+        assert_eq!(
+            colors.get_indicator_from_elem(&Elem::FileIndicator { exec: true }),
+            Indicator::from("ex")
+        );
+    }
+
+    #[test]
+    fn test_directory_indicator_lscolors_defaults() {
+        let colors = Colors::new(super::ThemeOption::Default);
+        assert_eq!(
+            colors.get_indicator_from_elem(&Elem::DirectoryIndicator),
+            Indicator::from("di")
         );
     }
 }

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -104,6 +104,8 @@ pub struct Theme {
     #[serde(deserialize_with = "deserialize_color")]
     pub group: Color,
     #[serde(deserialize_with = "deserialize_optional_color")]
+    pub file_indicator: Option<Color>,
+    #[serde(deserialize_with = "deserialize_optional_color")]
     pub directory_indicator: Option<Color>,
     pub permission: Permission,
     pub date: Date,
@@ -401,6 +403,7 @@ impl Theme {
         Theme {
             user: Color::AnsiValue(230),  // Cornsilk1
             group: Color::AnsiValue(187), // LightYellow3
+            file_indicator: None,
             directory_indicator: None,
             permission: Permission::default(),
             file_type: FileType::default(),

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -510,6 +510,20 @@ permission:
     }
 
     #[test]
+    fn test_file_indicator_override() {
+        let theme = Theme::with_yaml(
+            r#"---
+file-indicator: 36
+"#,
+        )
+        .unwrap();
+        let mut expected_theme = Theme::default_dark();
+        use crossterm::style::Color;
+        expected_theme.file_indicator = Some(Color::AnsiValue(36));
+        assert_eq!(theme, expected_theme)
+    }
+
+    #[test]
     fn test_directory_indicator_override() {
         let theme = Theme::with_yaml(
             r#"---

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -92,7 +92,7 @@ impl FileType {
     pub fn render(self, colors: &Colors) -> ColoredString {
         match self {
             FileType::File { exec, .. } => colors.colorize('.', &Elem::File { exec, uid: false }),
-            FileType::Directory { .. } => colors.colorize('d', &Elem::Dir { uid: false }),
+            FileType::Directory { .. } => colors.colorize('d', &Elem::DirectoryIndicator),
             FileType::Pipe => colors.colorize('|', &Elem::Pipe),
             FileType::SymLink { .. } => colors.colorize('l', &Elem::SymLink),
             FileType::BlockDevice => colors.colorize('b', &Elem::BlockDevice),

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -91,7 +91,7 @@ impl FileType {
 impl FileType {
     pub fn render(self, colors: &Colors) -> ColoredString {
         match self {
-            FileType::File { exec, .. } => colors.colorize('.', &Elem::File { exec, uid: false }),
+            FileType::File { exec, .. } => colors.colorize('.', &Elem::FileIndicator { exec }),
             FileType::Directory { .. } => colors.colorize('d', &Elem::DirectoryIndicator),
             FileType::Pipe => colors.colorize('|', &Elem::Pipe),
             FileType::SymLink { .. } => colors.colorize('l', &Elem::SymLink),


### PR DESCRIPTION
Attempt at fixing #574 . Provide two new theme options:
```yaml
file-indicator: 43
directory-indicator: 65
```
(numbers in example are arbitrary, and can be any color currently supported)

I thought one for each made more sense than a common one. Feel free to disagree.


The indicators use the theme in the file if found, if not they use the defaults for file/directory names. LS_COLORS color is only used if no theme setting is provided. This is based upon the following comment in the feature suggestion, which I found reasonable: 
> I suggest an optional setting in the theme yaml. If this field is absent, fall back to the file type color from LS_COLORS.  

I was unsure on how to test the LS_COLORS bits, so have briefly tested that manually. Please tell me if I'm missing something and there are good ways of writing tests for them 🙂 


In general I'm fairly new to Rust, so any feedback is greatly appreciated! 🙂 

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)