### PR TITLE
Add `long` option to config file (equivalent to --long)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--system-protected` to include files with the Windows `system` flag set,
   on other platform the same as `--all` [#752](https://github.com/Peltoche/lsd/issues/752)
 - Add many icons from https://github.com/Peltoche/lsd/issues/764 [@TruncatedDinosour](https://ari-web.xyz/gh)
+- Add `long` option to config file to default to long display [jfmontanaro](https://github.com/jfmontanaro)
 
 ### Fixed
 - Do not quote filename when piping into another program from [TeamTamoad](https://github.com/TeamTamoad)
@@ -22,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [`LS_COLORS`](README.md#Colors) can be used to customize.
 - Handle dereference (-L) with broken symlink from [r3dArch](https://github.com/r3dArch)
 - Avoid using Clap's deprecated structs and functions [sudame](https://github.com/sudame)
-- Add `long` option to config file to default to long display [jfmontanaro](https://github.com/jfmontanaro)
 
 ## [0.23.1] - 2022-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--system-protected` to include files with the Windows `system` flag set,
   on other platform the same as `--all` [#752](https://github.com/Peltoche/lsd/issues/752)
 - Add many icons from https://github.com/Peltoche/lsd/issues/764 [@TruncatedDinosour](https://ari-web.xyz/gh)
-- Add `long` option to config file to default to long display [jfmontanaro](https://github.com/jfmontanaro)
+- Add `always-long` option to config file to default to long display [jfmontanaro](https://github.com/jfmontanaro)
 
 ### Fixed
 - Do not quote filename when piping into another program from [TeamTamoad](https://github.com/TeamTamoad)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [`LS_COLORS`](README.md#Colors) can be used to customize.
 - Handle dereference (-L) with broken symlink from [r3dArch](https://github.com/r3dArch)
 - Avoid using Clap's deprecated structs and functions [sudame](https://github.com/sudame)
+- Add `long` option to config file to default to long display [jfmontanaro](https://github.com/jfmontanaro)
 
 ## [0.23.1] - 2022-09-13
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ blocks:
   - date
   - name
 
+# == Long ==
+# Always display file metadata (i.e. the blocks specified above.)
+long: false
+
 # == Color ==
 # This has various color options. (Will be expanded in the future.)
 color:
@@ -172,11 +176,6 @@ indicators: false
 # called "one-per-line". It might be changed in the future.
 # Possible values: grid, tree, oneline
 layout: grid
-
-# == Long ==
-# Whether to use "long" display mode by default, showing additional columns
-# (specified above in "blocks")
-long: false
 
 # == Recursion ==
 recursion:

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ blocks:
   - date
   - name
 
-# == Long ==
+# == Long form display ==
 # Always display file metadata (i.e. the blocks specified above.)
-long: false
+always-long: false
 
 # == Color ==
 # This has various color options. (Will be expanded in the future.)

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ indicators: false
 # Possible values: grid, tree, oneline
 layout: grid
 
+# == Long ==
+# Whether to use "long" display mode by default, showing additional columns
+# (specified above in "blocks")
+long: false
+
 # == Recursion ==
 recursion:
   # Whether to enable recursion.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgAction, Command, ValueHint};
+use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint};
 
 pub fn build() -> Command<'static> {
     Command::new("lsd")
@@ -85,11 +85,31 @@ pub fn build() -> Command<'static> {
                 .takes_value(true)
         )
         .arg(
+            Arg::new("grid")
+                 .long("grid")
+                 .action(ArgAction::SetTrue)
+                 .conflicts_with("long")
+                 .help("Display in a grid (default)")
+        )
+        .arg(
+            Arg::new("tree")
+                .long("tree")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("recursive")
+                .help("Recurse into directories and present the result as a tree"),
+        )
+        .arg(
             Arg::new("oneline")
                 .short('1')
                 .long("oneline")
                 .action(ArgAction::SetTrue)
                 .help("Display one entry per line"),
+        )
+        .group(
+            ArgGroup::new("layout")
+                      .arg("grid")
+                      .arg("tree")
+                      .arg("oneline")
         )
         .arg(
             Arg::new("recursive")
@@ -105,13 +125,6 @@ pub fn build() -> Command<'static> {
                 .long("human-readable")
                 .action(ArgAction::SetTrue)
                 .help("For ls compatibility purposes ONLY, currently set by default"),
-        )
-        .arg(
-            Arg::new("tree")
-                .long("tree")
-                .action(ArgAction::SetTrue)
-                .conflicts_with("recursive")
-                .help("Recurse into directories and present the result as a tree"),
         )
         .arg(
             Arg::new("depth")

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgAction, ArgGroup, Command, ValueHint};
+use clap::{Arg, ArgAction, Command, ValueHint};
 
 pub fn build() -> Command<'static> {
     Command::new("lsd")
@@ -85,13 +85,6 @@ pub fn build() -> Command<'static> {
                 .takes_value(true)
         )
         .arg(
-            Arg::new("grid")
-                 .long("grid")
-                 .action(ArgAction::SetTrue)
-                 .conflicts_with("long")
-                 .help("Display in a grid (default)")
-        )
-        .arg(
             Arg::new("tree")
                 .long("tree")
                 .action(ArgAction::SetTrue)
@@ -104,12 +97,6 @@ pub fn build() -> Command<'static> {
                 .long("oneline")
                 .action(ArgAction::SetTrue)
                 .help("Display one entry per line"),
-        )
-        .group(
-            ArgGroup::new("layout")
-                      .arg("grid")
-                      .arg("tree")
-                      .arg("oneline")
         )
         .arg(
             Arg::new("recursive")

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -36,7 +36,7 @@ pub struct Config {
     pub ignore_globs: Option<Vec<String>>,
     pub indicators: Option<bool>,
     pub layout: Option<Layout>,
-    pub long: Option<bool>,
+    pub always_long: Option<bool>,
     pub recursion: Option<Recursion>,
     pub size: Option<SizeFlag>,
     pub permission: Option<PermissionFlag>,
@@ -89,7 +89,7 @@ impl Config {
             ignore_globs: None,
             indicators: None,
             layout: None,
-            long: None,
+            always_long: None,
             recursion: None,
             size: None,
             permission: None,
@@ -214,9 +214,9 @@ blocks:
   - date
   - name
 
-# == Long ==
+# == Long form display ==
 # Always display file metadata (i.e. the blocks specified above.)
-long: false
+always-long: false
 
 # == Color ==
 # This has various color options. (Will be expanded in the future.)
@@ -379,7 +379,7 @@ mod tests {
                 ignore_globs: None,
                 indicators: Some(false),
                 layout: Some(Layout::Grid),
-                long: Some(false),
+                always_long: Some(false),
                 recursion: Some(config_file::Recursion {
                     enabled: Some(false),
                     depth: None,

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub ignore_globs: Option<Vec<String>>,
     pub indicators: Option<bool>,
     pub layout: Option<Layout>,
+    pub long: Option<bool>,
     pub recursion: Option<Recursion>,
     pub size: Option<SizeFlag>,
     pub permission: Option<PermissionFlag>,
@@ -88,6 +89,7 @@ impl Config {
             ignore_globs: None,
             indicators: None,
             layout: None,
+            long: None,
             recursion: None,
             size: None,
             permission: None,
@@ -273,6 +275,11 @@ indicators: false
 # Possible values: grid, tree, oneline
 layout: grid
 
+# == Long ==
+# Whether to use "long" display mode by default, showing additional columns
+# (specified above in "blocks")
+long: false
+
 # == Recursion ==
 recursion:
   # Whether to enable recursion.
@@ -373,6 +380,7 @@ mod tests {
                 ignore_globs: None,
                 indicators: Some(false),
                 layout: Some(Layout::Grid),
+                long: Some(false),
                 recursion: Some(config_file::Recursion {
                     enabled: Some(false),
                     depth: None,

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -214,6 +214,10 @@ blocks:
   - date
   - name
 
+# == Long ==
+# Always display file metadata (i.e. the blocks specified above.)
+long: false
+
 # == Color ==
 # This has various color options. (Will be expanded in the future.)
 color:
@@ -274,11 +278,6 @@ indicators: false
 # called "one-per-line". It might be changed in the future.
 # Possible values: grid, tree, oneline
 layout: grid
-
-# == Long ==
-# Whether to use "long" display mode by default, showing additional columns
-# (specified above in "blocks")
-long: false
 
 # == Recursion ==
 recursion:

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -153,6 +153,8 @@ impl Configurable<Self> for Blocks {
             } else {
                 Some(Self(blocks))
             }
+        } else if let Some(true) = config.long {
+            Some(Self::long())
         } else {
             None
         }
@@ -422,6 +424,14 @@ mod test_blocks {
         let mut c = Config::with_none();
         c.blocks = Some(vec!["permission".into(), "group".into(), "date".into()]);
         let blocks = Blocks(vec![Block::Permission, Block::Group, Block::Date]);
+        assert_eq!(Some(blocks), Blocks::from_config(&c));
+    }
+
+    #[test]
+    fn test_from_config_with_long() {
+        let mut c = Config::with_none();
+        c.long = Some(true);
+        let blocks = Blocks::long();
         assert_eq!(Some(blocks), Blocks::from_config(&c));
     }
 

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -74,7 +74,7 @@ impl Configurable<Self> for Blocks {
     /// This returns [Default::default] unless either the "long" argument is passed,
     /// or "always_long" is set to `true` in the config file **and** the "grid"
     /// argument is *not* passed.
-    /// 
+    ///
     /// In these cases, the first value that is not [None] is used. The order of precedence
     /// for the value used is:
     /// - [from_arg_matches](Blocks::from_arg_matches)

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -97,11 +97,6 @@ impl Configurable<Self> for Blocks {
             blocks = Default::default();
         }
 
-        // "grid" overrides "long"
-        if matches.get_one("grid") == Some(&true) {
-            blocks = Default::default();
-        }
-
         if let Some(value) = Self::from_arg_matches(matches) {
             blocks = value;
         }
@@ -283,19 +278,6 @@ mod test_blocks {
     }
 
     #[test]
-    fn test_configure_from_with_grid_and_always_long() {
-        let argv = ["lsd", "--grid"];
-        let mut c = Config::with_none();
-        c.always_long = Some(true);
-        let target = Blocks(vec![Block::Name]);
-
-        let matches = app::build().try_get_matches_from(argv).unwrap();
-        let result = Blocks::configure_from(&matches, &c);
-
-        assert_eq!(result, target);
-    }
-
-    #[test]
     fn test_configure_from_with_inode() {
         let argv = ["lsd", "--inode"];
         let target = Blocks(vec![Block::INode, Block::Name]);
@@ -450,7 +432,7 @@ mod test_blocks {
     }
 
     #[test]
-    fn test_from_config_with_long() {
+    fn test_from_config_with_always_long() {
         let mut c = Config::with_none();
         c.always_long = Some(true);
         let blocks = Blocks::long();

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -168,10 +168,6 @@ impl Configurable<Self> for Blocks {
             None
         }
     }
-
-    fn from_environment() -> Option<Self> {
-        None
-    }
 }
 
 /// The default value for `Blocks` contains a [Vec] of [Name](Block::Name).

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -81,13 +81,13 @@ impl Configurable<Self> for Blocks {
     /// `Blocks` does not contain a [Block] of variant [INode](Block::INode) yet, one is prepended
     /// to the returned value.
     fn configure_from(matches: &ArgMatches, config: &Config) -> Self {
-        let mut blocks = if matches.get_one("long") == Some(&true) {
+        let mut blocks = if matches.get_one("long") == Some(&true) || config.long.unwrap_or(false) {
             Self::long()
         } else {
             Default::default()
         };
 
-        if matches.get_one("long") == Some(&true) {
+        if matches.get_one("long") == Some(&true) || config.long.unwrap_or(false) {
             if let Some(value) = Self::from_config(config) {
                 blocks = value;
             }

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -26,7 +26,9 @@ impl Configurable<Layout> for Layout {
     /// arguments is greater than 1, this also returns the [OneLine](Layout::OneLine) variant.
     /// Finally if neither of them is passed, this returns [None].
     fn from_arg_matches(matches: &ArgMatches) -> Option<Self> {
-        if matches.get_one("tree") == Some(&true) {
+        if matches.get_one("grid") == Some(&true) {
+            Some(Self::Grid)
+        } else if matches.get_one("tree") == Some(&true) {
             Some(Self::Tree)
         } else if matches.get_one("long") == Some(&true)
             || matches.get_one("oneline") == Some(&true)
@@ -47,7 +49,7 @@ impl Configurable<Layout> for Layout {
     /// this returns the corresponding `Layout` variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if config.long == Some(true) {
+        if config.always_long == Some(true) {
             Some(Self::OneLine)
         } else {
             config.layout
@@ -68,6 +70,13 @@ mod test {
         let argv = ["lsd"];
         let matches = app::build().try_get_matches_from(argv).unwrap();
         assert_eq!(None, Layout::from_arg_matches(&matches));
+    }
+
+    #[test]
+    fn test_from_arg_matches_grid() {
+        let argv = ["lsd", "--grid"];
+        let matches = app::build().try_get_matches_from(argv).unwrap();
+        assert_eq!(Some(Layout::Grid), Layout::from_arg_matches(&matches));
     }
 
     #[test]
@@ -127,7 +136,7 @@ mod test {
     #[test]
     fn test_from_config_long() {
         let mut c = Config::with_none();
-        c.long = Some(true);
+        c.always_long = Some(true);
         assert_eq!(Some(Layout::OneLine), Layout::from_config(&c));
     }
 }

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -26,9 +26,7 @@ impl Configurable<Layout> for Layout {
     /// arguments is greater than 1, this also returns the [OneLine](Layout::OneLine) variant.
     /// Finally if neither of them is passed, this returns [None].
     fn from_arg_matches(matches: &ArgMatches) -> Option<Self> {
-        if matches.get_one("grid") == Some(&true) {
-            Some(Self::Grid)
-        } else if matches.get_one("tree") == Some(&true) {
+        if matches.get_one("tree") == Some(&true) {
             Some(Self::Tree)
         } else if matches.get_one("long") == Some(&true)
             || matches.get_one("oneline") == Some(&true)
@@ -70,13 +68,6 @@ mod test {
         let argv = ["lsd"];
         let matches = app::build().try_get_matches_from(argv).unwrap();
         assert_eq!(None, Layout::from_arg_matches(&matches));
-    }
-
-    #[test]
-    fn test_from_arg_matches_grid() {
-        let argv = ["lsd", "--grid"];
-        let matches = app::build().try_get_matches_from(argv).unwrap();
-        assert_eq!(Some(Layout::Grid), Layout::from_arg_matches(&matches));
     }
 
     #[test]

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -123,4 +123,11 @@ mod test {
         c.layout = Some(Layout::Grid);
         assert_eq!(Some(Layout::Grid), Layout::from_config(&c));
     }
+
+    #[test]
+    fn test_from_config_long() {
+        let mut c = Config::with_none();
+        c.long = Some(true);
+        assert_eq!(Some(Layout::OneLine), Layout::from_config(&c));
+    }
 }

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -47,7 +47,11 @@ impl Configurable<Layout> for Layout {
     /// this returns the corresponding `Layout` variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        config.layout
+        if config.long == Some(true) {
+            Some(Self::OneLine)
+        } else {
+            config.layout
+        }
     }
 }
 


### PR DESCRIPTION
I ran into the same issue as #621, expecting that explicitly-specified `blocks` in the config file would result in them being displayed by default. IMO it would be nice to have a config option for this - I prefer the config file over aliasing `ls` to `lsd -l` in my shell, because that way all of my settings are collected in one place.

And having it right below the `blocks` section in the example makes it harder to misunderstand how `blocks` works, the way I and the other commenter did.

Happy to make any changes, or just drop it if you don't feel this would be a good add. `alias ls='lsd -l'` _does_ work, after all.

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [ ] ~~Update man page at lsd/doc/lsd.md (if applicable)~~