### PR TITLE
Add IEC and SI units/unit prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add IEC and SI units and unit prefixes to `--size`
 - In keeping with the coreutils change, add quotes and escapes for necessary filenames from [merelymyself](https://github.com/merelymyself)
 - Add support for icon theme from [zwpaper](https://github.com/zwpaper)
 - Add icon for kt and kts from [LeeWeeder](https://github.com/LeeWeeder)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ recursion:
 
 # == Size ==
 # Specifies the format of the size column.
-# Possible values: default, short, bytes
+# Possible values: default, short, iec, si, bytes
 size: default
 
 # == Permission ==

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -123,7 +123,7 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 : How to display permissions [default: rwx]  [possible values: rwx, octal]
 
 `--size <size>...`
-: How to display size [default: default]  [possible values: default, short, bytes]
+: How to display size [default: default]  [possible values: default, short, iec, si, bytes]
 
 `--sort <WORD>...`
 : Sort by WORD instead of name [possible values: size, time, version, extension]

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,7 +73,7 @@ pub struct Cli {
     pub permission: Option<String>,
 
     /// How to display size [default: default]
-    #[arg(long, value_name = "MODE", value_parser = ["default", "short", "bytes"])]
+    #[arg(long, value_name = "MODE", value_parser = ["default", "short", "iec", "si", "bytes"])]
     pub size: Option<String>,
 
     /// Display the total size of directories

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -284,7 +284,7 @@ recursion:
 
 # == Size ==
 # Specifies the format of the size column.
-# Possible values: default, short, bytes
+# Possible values: default, short, iec, si, bytes
 size: default
 
 # == Permission ==

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -17,6 +17,10 @@ pub enum SizeFlag {
     Default,
     /// The variant to show file size with only the SI unit prefix.
     Short,
+    /// The variant to show file size with IEC unit prefix and a B for bytes
+    Iec,
+    /// The variant to show file size with SI units and SI unit prefixes and a B for bytes
+    Si,
     /// The variant to show file size in bytes.
     Bytes,
 }
@@ -26,6 +30,8 @@ impl SizeFlag {
         match value {
             "default" => Self::Default,
             "short" => Self::Short,
+            "iec" => Self::Iec,
+            "si" => Self::Si,
             "bytes" => Self::Bytes,
             // Invalid value should be handled by `clap` when building an `Cli`
             other => unreachable!("Invalid value '{other}' for 'size'"),
@@ -98,6 +104,20 @@ mod test {
     }
 
     #[test]
+    fn test_from_cli_iec() {
+        let argv = ["lsd", "--size", "iec"];
+        let cli = Cli::try_parse_from(argv).unwrap();
+        assert_eq!(Some(SizeFlag::Iec), SizeFlag::from_cli(&cli));
+    }
+
+    #[test]
+    fn test_from_cli_si() {
+        let argv = ["lsd", "--size", "si"];
+        let cli = Cli::try_parse_from(argv).unwrap();
+        assert_eq!(Some(SizeFlag::Si), SizeFlag::from_cli(&cli));
+    }
+
+    #[test]
     fn test_from_cli_bytes() {
         let argv = ["lsd", "--size", "bytes"];
         let cli = Cli::try_parse_from(argv).unwrap();
@@ -141,6 +161,20 @@ mod test {
         let mut c = Config::with_none();
         c.size = Some(SizeFlag::Short);
         assert_eq!(Some(SizeFlag::Short), SizeFlag::from_config(&c));
+    }
+
+    #[test]
+    fn test_from_config_iec() {
+        let mut c = Config::with_none();
+        c.size = Some(SizeFlag::Iec);
+        assert_eq!(Some(SizeFlag::Iec), SizeFlag::from_config(&c));
+    }
+
+    #[test]
+    fn test_from_config_si() {
+        let mut c = Config::with_none();
+        c.size = Some(SizeFlag::Si);
+        assert_eq!(Some(SizeFlag::Si), SizeFlag::from_config(&c));
     }
 
     #[test]

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -113,18 +113,34 @@ impl Size {
         match flags.size {
             SizeFlag::Si => match unit {
                 Unit::Byte => self.bytes.to_string(),
-                Unit::Kilo => self.format_size(((self.bytes as f64 / KB as f64) * 10.0).round() / 10.0),
-                Unit::Mega => self.format_size(((self.bytes as f64 / MB as f64) * 10.0).round() / 10.0),
-                Unit::Giga => self.format_size(((self.bytes as f64 / GB as f64) * 10.0).round() / 10.0),
-                Unit::Tera => self.format_size(((self.bytes as f64 / TB as f64) * 10.0).round() / 10.0),
-            }
+                Unit::Kilo => {
+                    self.format_size(((self.bytes as f64 / KB as f64) * 10.0).round() / 10.0)
+                }
+                Unit::Mega => {
+                    self.format_size(((self.bytes as f64 / MB as f64) * 10.0).round() / 10.0)
+                }
+                Unit::Giga => {
+                    self.format_size(((self.bytes as f64 / GB as f64) * 10.0).round() / 10.0)
+                }
+                Unit::Tera => {
+                    self.format_size(((self.bytes as f64 / TB as f64) * 10.0).round() / 10.0)
+                }
+            },
             _ => match unit {
                 Unit::Byte => self.bytes.to_string(),
-                Unit::Kilo => self.format_size(((self.bytes as f64 / KIB as f64) * 10.0).round() / 10.0),
-                Unit::Mega => self.format_size(((self.bytes as f64 / MIB as f64) * 10.0).round() / 10.0),
-                Unit::Giga => self.format_size(((self.bytes as f64 / GIB as f64) * 10.0).round() / 10.0),
-                Unit::Tera => self.format_size(((self.bytes as f64 / TIB as f64) * 10.0).round() / 10.0),
-            }
+                Unit::Kilo => {
+                    self.format_size(((self.bytes as f64 / KIB as f64) * 10.0).round() / 10.0)
+                }
+                Unit::Mega => {
+                    self.format_size(((self.bytes as f64 / MIB as f64) * 10.0).round() / 10.0)
+                }
+                Unit::Giga => {
+                    self.format_size(((self.bytes as f64 / GIB as f64) * 10.0).round() / 10.0)
+                }
+                Unit::Tera => {
+                    self.format_size(((self.bytes as f64 / TIB as f64) * 10.0).round() / 10.0)
+                }
+            },
         }
     }
 
@@ -166,7 +182,7 @@ impl Size {
 
 #[cfg(test)]
 mod test {
-    use super::{Size, KIB, MIB, GIB, TIB};
+    use super::{Size, GIB, KIB, MIB, TIB};
     use crate::color::{Colors, ThemeOption};
     use crate::flags::{Flags, SizeFlag};
 


### PR DESCRIPTION
`lsd` currently uses IEC units, but SI prefixes. This PR adds two values to the `--size` flag and the associated config file entry.

- `--size iec` uses IEC units and IEC prefixes (KiB, MiB, etc.)
- `--size si` uses SI units and SI prefixes (KB, MB, etc.)

A 4,000,000 byte would thus be represented as:
- `3.8 MB` with `--size default`
- `3.8 MiB` with `--size iec`
- `4.0 MB` with `--size si`

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [x] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)