### PR TITLE
change executable file extentions, add cmd, com, vbs, vbe, and dll

### DIFF
--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -16,7 +16,7 @@ pub enum FileType {
 
 impl FileType {
     #[cfg(windows)]
-    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "bat", "ps1", "cmd", "com", "msi" ];
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com" ];
 
     #[cfg(unix)]
     pub fn new(

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -16,7 +16,7 @@ pub enum FileType {
 
 impl FileType {
     #[cfg(windows)]
-    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1"];
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "bat", "ps1", "cmd", "com"];
 
     #[cfg(unix)]
     pub fn new(

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -16,7 +16,7 @@ pub enum FileType {
 
 impl FileType {
     #[cfg(windows)]
-    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "bat", "ps1", "cmd", "com"];
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "bat", "ps1", "cmd", "com", "msi" ];
 
     #[cfg(unix)]
     pub fn new(

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -16,7 +16,7 @@ pub enum FileType {
 
 impl FileType {
     #[cfg(windows)]
-    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com" ];
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com", "py", "sh", "lua", "js", "rb", "pl", "vbs", "vbe" ];
 
     #[cfg(unix)]
     pub fn new(

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -16,7 +16,7 @@ pub enum FileType {
 
 impl FileType {
     #[cfg(windows)]
-    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com", "py", "sh", "lua", "js", "rb", "pl", "vbs", "vbe" ];
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com", "vbs", "vbe" ];
 
     #[cfg(unix)]
     pub fn new(

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -16,7 +16,7 @@ pub enum FileType {
 
 impl FileType {
     #[cfg(windows)]
-    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com", "vbs", "vbe" ];
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1", "cmd", "com", "vbs", "vbe", "dll" ];
 
     #[cfg(unix)]
     pub fn new(


### PR DESCRIPTION
cmd is another way of naming bat files, com is an old filetype that afaik isn't really used anymore but its still technically treated as a program by windows.  msi on the other hand isn't actually a program, its just an installer package that gets interpreted by msiexec.exe, it would be like saying that deb files are executable on linux.