### PR TITLE
Move locale based date behind a flag

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -180,10 +180,10 @@ pub struct Cli {
 fn validate_date_argument(arg: &str) -> Result<String, String> {
     if arg.starts_with('+') {
         validate_time_format(arg)
-    } else if arg == "date" || arg == "relative" {
+    } else if arg == "date" || arg == "relative" || arg == "locale" {
         Result::Ok(arg.to_owned())
     } else {
-        Result::Err("possible values: date, relative, +date-time-format".to_owned())
+        Result::Err("possible values: date, locale, relative, +date-time-format".to_owned())
     }
 }
 

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -12,6 +12,7 @@ use crate::print_error;
 pub enum DateFlag {
     #[default]
     Date,
+    Locale,
     Relative,
     Iso,
     Formatted(String),
@@ -33,6 +34,7 @@ impl DateFlag {
         let value = value.as_ref();
         match value {
             "date" => Some(Self::Date),
+            "locale" => Some(Self::Locale),
             "relative" => Some(Self::Relative),
             _ if value.starts_with('+') => Self::from_format_string(value),
             _ => {
@@ -77,6 +79,7 @@ impl Configurable<Self> for DateFlag {
             match value.as_str() {
                 "full-iso" => Some(Self::Formatted("%F %T.%f %z".into())),
                 "long-iso" => Some(Self::Formatted("%F %R".into())),
+                "locale" => Some(Self::Locale),
                 "iso" => Some(Self::Iso),
                 _ if value.starts_with('+') => Self::from_format_string(&value),
                 _ => {
@@ -112,6 +115,13 @@ mod test {
         let argv = ["lsd", "--date", "date"];
         let cli = Cli::try_parse_from(argv).unwrap();
         assert_eq!(Some(DateFlag::Date), DateFlag::from_cli(&cli));
+    }
+
+    #[test]
+    fn test_from_cli_locale() {
+        let argv = ["lsd", "--date", "locale"];
+        let cli = Cli::try_parse_from(argv).unwrap();
+        assert_eq!(Some(DateFlag::Locale), DateFlag::from_cli(&cli));
     }
 
     #[test]

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -47,7 +47,8 @@ impl Date {
 
         if let Date::Date(val) = self {
             match &flags.date {
-                DateFlag::Date => val.format_localized("%c", locale).to_string(),
+                DateFlag::Date => val.format("%c").to_string(),
+                DateFlag::Locale => val.format_localized("%c", locale).to_string(),
                 DateFlag::Relative => HumanTime::from(*val - Local::now()).to_string(),
                 DateFlag::Iso => {
                     // 365.2425 * 24 * 60 * 60 = 31556952 seconds per year
@@ -131,7 +132,7 @@ mod test {
 
         assert_eq!(
             creation_date
-                .format_localized("%c", current_locale())
+                .format("%c")
                 .to_string()
                 .with(Color::AnsiValue(40)),
             date.render(&colors, &flags)
@@ -158,7 +159,7 @@ mod test {
 
         assert_eq!(
             creation_date
-                .format_localized("%c", current_locale())
+                .format("%c")
                 .to_string()
                 .with(Color::AnsiValue(42)),
             date.render(&colors, &flags)
@@ -185,7 +186,7 @@ mod test {
 
         assert_eq!(
             creation_date
-                .format_localized("%c", current_locale())
+                .format("%c")
                 .to_string()
                 .with(Color::AnsiValue(36)),
             date.render(&colors, &flags)
@@ -303,6 +304,36 @@ mod test {
                 .format("%F")
                 .to_string()
                 .with(Color::AnsiValue(36)),
+            date.render(&colors, &flags)
+        );
+
+        fs::remove_file(file_path).unwrap();
+    }
+
+    #[test]
+    fn test_locale_format_now() {
+        let mut file_path = env::temp_dir();
+        file_path.push("test_locale_format_now.tmp");
+
+        let creation_date = Local::now();
+        let success = cross_platform_touch(&file_path, &creation_date)
+            .unwrap()
+            .success();
+        assert!(success, "failed to exec touch");
+
+        let colors = Colors::new(ThemeOption::Default);
+        let date = Date::from(&file_path.metadata().unwrap());
+
+        let flags = Flags {
+            date: DateFlag::Locale,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            creation_date
+                .format_localized("%c", current_locale())
+                .to_string()
+                .with(Color::AnsiValue(40)),
             date.render(&colors, &flags)
         );
 


### PR DESCRIPTION
This makes sure the date behaviour is kept to previous default.
https://github.com/lsd-rs/lsd/issues/828

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)