### PR TITLE
Added complete color theming support for Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add complete color theming support for Git [k4yt3x](https://github.com/k4yt3x]
 - Add [Git integration](https://github.com/Peltoche/lsd/issues/7) from [hpwxf](https://github.com/hpwxf)
 - In keeping with the coreutils change, add quotes and escapes for necessary filenames from [merelymyself](https://github.com/merelymyself)
 - Add support for icon theme from [zwpaper](https://github.com/zwpaper)

--- a/README.md
+++ b/README.md
@@ -293,6 +293,17 @@ links:
   valid: 13
   invalid: 245
 tree-edge: 245
+git-status:
+  default: 245
+  unmodified: 245
+  ignored: 245
+  new-in-index: dark_green
+  new-in-workdir: dark_green
+  typechange: dark_yellow
+  deleted: dark_red
+  renamed: dark_green
+  modified: dark_yellow
+  conflicted: dark_red
 ```
 
 When creating a theme for `lsd`, you can specify any part of the default theme,

--- a/src/color.rs
+++ b/src/color.rs
@@ -127,16 +127,36 @@ impl Elem {
             Elem::Links { valid: false } => theme.links.invalid,
             Elem::Links { valid: true } => theme.links.valid,
 
-            Elem::GitStatus { status: GitStatus::Default } => theme.git_status.default,
-            Elem::GitStatus { status: GitStatus::Unmodified } => theme.git_status.unmodified,
-            Elem::GitStatus { status: GitStatus::Ignored } => theme.git_status.ignored,
-            Elem::GitStatus { status: GitStatus::NewInIndex } => theme.git_status.new_in_index,
-            Elem::GitStatus { status: GitStatus::NewInWorkdir } => theme.git_status.new_in_workdir,
-            Elem::GitStatus { status: GitStatus::Typechange } => theme.git_status.typechange,
-            Elem::GitStatus { status: GitStatus::Deleted } => theme.git_status.deleted,
-            Elem::GitStatus { status: GitStatus::Renamed } => theme.git_status.renamed,
-            Elem::GitStatus { status: GitStatus::Modified } => theme.git_status.modified,
-            Elem::GitStatus { status: GitStatus::Conflicted } => theme.git_status.conflicted,
+            Elem::GitStatus {
+                status: GitStatus::Default,
+            } => theme.git_status.default,
+            Elem::GitStatus {
+                status: GitStatus::Unmodified,
+            } => theme.git_status.unmodified,
+            Elem::GitStatus {
+                status: GitStatus::Ignored,
+            } => theme.git_status.ignored,
+            Elem::GitStatus {
+                status: GitStatus::NewInIndex,
+            } => theme.git_status.new_in_index,
+            Elem::GitStatus {
+                status: GitStatus::NewInWorkdir,
+            } => theme.git_status.new_in_workdir,
+            Elem::GitStatus {
+                status: GitStatus::Typechange,
+            } => theme.git_status.typechange,
+            Elem::GitStatus {
+                status: GitStatus::Deleted,
+            } => theme.git_status.deleted,
+            Elem::GitStatus {
+                status: GitStatus::Renamed,
+            } => theme.git_status.renamed,
+            Elem::GitStatus {
+                status: GitStatus::Modified,
+            } => theme.git_status.modified,
+            Elem::GitStatus {
+                status: GitStatus::Conflicted,
+            } => theme.git_status.conflicted,
         }
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -126,7 +126,17 @@ impl Elem {
             Elem::TreeEdge => theme.tree_edge,
             Elem::Links { valid: false } => theme.links.invalid,
             Elem::Links { valid: true } => theme.links.valid,
-            Elem::GitStatus { .. } => theme.git_status.default,
+
+            Elem::GitStatus { status: GitStatus::Default } => theme.git_status.default,
+            Elem::GitStatus { status: GitStatus::Unmodified } => theme.git_status.unmodified,
+            Elem::GitStatus { status: GitStatus::Ignored } => theme.git_status.ignored,
+            Elem::GitStatus { status: GitStatus::NewInIndex } => theme.git_status.new_in_index,
+            Elem::GitStatus { status: GitStatus::NewInWorkdir } => theme.git_status.new_in_workdir,
+            Elem::GitStatus { status: GitStatus::Typechange } => theme.git_status.typechange,
+            Elem::GitStatus { status: GitStatus::Deleted } => theme.git_status.deleted,
+            Elem::GitStatus { status: GitStatus::Renamed } => theme.git_status.renamed,
+            Elem::GitStatus { status: GitStatus::Modified } => theme.git_status.modified,
+            Elem::GitStatus { status: GitStatus::Conflicted } => theme.git_status.conflicted,
         }
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -95,7 +95,9 @@ impl GitCache {
         match std::fs::canonicalize(filepath) {
             Ok(filename) => Some(self.inner_get(&filename, is_directory)),
             Err(err) => {
-                crate::print_error!("Cannot get git status for {:?}:  {}", filepath, err);
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    crate::print_error!("Cannot get git status for {:?}:  {}", filepath, err);
+                }
                 None
             }
         }

--- a/src/theme/color.rs
+++ b/src/theme/color.rs
@@ -241,6 +241,24 @@ pub struct Links {
 pub struct GitStatus {
     #[serde(deserialize_with = "deserialize_color")]
     pub default: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub unmodified: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub ignored: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub new_in_index: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub new_in_workdir: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub typechange: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub deleted: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub renamed: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub modified: Color,
+    #[serde(deserialize_with = "deserialize_color")]
+    pub conflicted: Color,
 }
 
 impl Default for Permission {
@@ -337,7 +355,16 @@ impl Default for Links {
 impl Default for GitStatus {
     fn default() -> Self {
         GitStatus {
-            default: Color::AnsiValue(13), // Pink
+            default: Color::AnsiValue(245),    // Grey
+            unmodified: Color::AnsiValue(245), // Grey
+            ignored: Color::AnsiValue(245),    // Grey
+            new_in_index: Color::DarkGreen,
+            new_in_workdir: Color::DarkGreen,
+            typechange: Color::DarkYellow,
+            deleted: Color::DarkRed,
+            renamed: Color::DarkGreen,
+            modified: Color::DarkYellow,
+            conflicted: Color::DarkRed,
         }
     }
 }


### PR DESCRIPTION
I've noticed that the recently merged Git feature only has one default color, so I completed it. I've added a default color theme for it that looks like this (ignore the conflicted, I didn't bother actually making a repo for it):

![image](https://github.com/lsd-rs/lsd/assets/21986859/5dd78f65-4c89-4f2e-88bb-2bfaacf00232)

... and with this theme of mine:

![image](https://github.com/lsd-rs/lsd/assets/21986859/df6e0ea6-87d5-4104-814b-64b8164fcc17)

... it looks like this, works fine:

![image](https://github.com/lsd-rs/lsd/assets/21986859/606fa7d2-d242-4310-bf28-af25c0108b96)

Edit: also suppressed ErrorKind::NotFound for Git status since if you don't this could happen when you are in a directory that's been deleted:

![image](https://github.com/lsd-rs/lsd/assets/21986859/c4f15864-0ea3-404a-87c4-714ac5e6bef5)

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)