### PR TITLE
Fixed file size colorizing with `--size=bytes` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle dereference (-L) with broken symlink from [r3dArch](https://github.com/r3dArch)
 - Avoid using Clap's deprecated structs and functions [sudame](https://github.com/sudame)
 - Icon theme with overrides from config [sudame](https://github.com/sudame)
+- Incorrect colorizing with `--size=bytes` [bells307](https://github.com/bells307)
 
 ## [0.23.1] - 2022-09-13
 

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -89,7 +89,17 @@ impl Size {
     fn paint(&self, colors: &Colors, flags: &Flags, content: String) -> ColoredString {
         let unit = self.get_unit(flags);
         let elem = match unit {
-            Unit::Byte | Unit::Kilo => &Elem::FileSmall,
+            Unit::Byte => {
+                let bytes = self.get_bytes();
+                if bytes >= GB {
+                    &Elem::FileLarge
+                } else if bytes >= MB {
+                    &Elem::FileMedium
+                } else {
+                    &Elem::FileSmall
+                }
+            }
+            Unit::Kilo => &Elem::FileSmall,
             Unit::Mega => &Elem::FileMedium,
             _ => &Elem::FileLarge,
         };

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -86,22 +86,15 @@ impl Size {
         ColoredString::new(Colors::default_style(), res)
     }
 
-    fn paint(&self, colors: &Colors, flags: &Flags, content: String) -> ColoredString {
-        let unit = self.get_unit(flags);
-        let elem = match unit {
-            Unit::Byte => {
-                let bytes = self.get_bytes();
-                if bytes >= GB {
-                    &Elem::FileLarge
-                } else if bytes >= MB {
-                    &Elem::FileMedium
-                } else {
-                    &Elem::FileSmall
-                }
-            }
-            Unit::Kilo => &Elem::FileSmall,
-            Unit::Mega => &Elem::FileMedium,
-            _ => &Elem::FileLarge,
+    fn paint(&self, colors: &Colors, content: String) -> ColoredString {
+        let bytes = self.get_bytes();
+
+        let elem = if bytes >= GB {
+            &Elem::FileLarge
+        } else if bytes >= MB {
+            &Elem::FileMedium
+        } else {
+            &Elem::FileSmall
         };
 
         colors.colorize(content, elem)
@@ -110,7 +103,7 @@ impl Size {
     pub fn render_value(&self, colors: &Colors, flags: &Flags) -> ColoredString {
         let content = self.value_string(flags);
 
-        self.paint(colors, flags, content)
+        self.paint(colors, content)
     }
 
     pub fn value_string(&self, flags: &Flags) -> String {
@@ -128,7 +121,7 @@ impl Size {
     pub fn render_unit(&self, colors: &Colors, flags: &Flags) -> ColoredString {
         let content = self.unit_string(flags);
 
-        self.paint(colors, flags, content)
+        self.paint(colors, content)
     }
 
     pub fn unit_string(&self, flags: &Flags) -> String {


### PR DESCRIPTION
<!--- PR Description --->

Fixed incorrect colorizing with `--size=bytes` described in issue #841 

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add changelog entry