### PR TITLE
:tada: add zwpaper to code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @meain @Peltoche
+*       @meain @Peltoche @zwpaper


### PR DESCRIPTION
it was needed to be listed on codeowner file in order to use the `/approve` command, so I am adding myself to the CODEOWNER file

/assign @meain 