### PR TITLE
Added newlines to warning message

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -180,7 +180,7 @@ impl Colors {
             ),
             ThemeOption::CustomLegacy(ref file) => {
                 print_output!(
-                    "Warning: the 'themes' directory is deprecated, use 'colors.yaml' instead."
+                    "Warning: the 'themes' directory is deprecated, use 'colors.yaml' instead.\n\n"
                 );
                 // TODO: drop the `themes` dir prefix, adding it here only for backwards compatibility
                 Some(


### PR DESCRIPTION


Addresses https://github.com/lsd-rs/lsd/issues/868. After building

``` shell
> ./target/release/lsd
Warning: the 'themes' directory is deprecated, use 'colors.yaml' instead.

 build.rs     Cargo.toml     ci           doc       README.md      src      tests
 Cargo.lock   CHANGELOG.md   CODEOWNERS   LICENSE   rustfmt.toml   target
```

---

#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests (Not needed)
- [x] Add changelog entry (Not a significant change)
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)