### PR TITLE
lsd does not seem to be available in Ubuntu repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install the patched fonts of powerline nerd-font and/or font-awesome. Have a loo
 | Windows                         | `scoop install lsd`                                                                                                                              |
 | Android (via Termux)            | `pkg install lsd`                                                                                                                                |
 | Debian sid and bookworm         | `apt install lsd`                                                                                                                                |
-| Ubuntu 23.04 (Lunar Lobster)    | `apt install lsd`                                                                                                                                |
+| Ubuntu 23.04 (Lunar Lobster)    | `snap install lsd`                                                                                                                                |
 | Earlier Ubuntu/Debian versions  | **snap discontinued**, use `sudo dpkg -i lsd_0.23.1_amd64.deb` and get `.deb` file from [release page](https://github.com/Peltoche/lsd/releases) |
 | Solus                           | `eopkg it lsd`                                                                                                                                   |
 | Void Linux                      | `sudo xbps-install lsd`                                                                                                                          |


### PR DESCRIPTION
This is the error I get:

```
No hay un paquete apt "lsd", pero hay un snap con ese nombre.
Intente «snap install lsd»
```

Spanish for: no `lsd` package, try... what I've written here


<!--- PR Description --->

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)