### PR TITLE
"Downloads" may not contain executables

### DIFF
--- a/src/theme/icon.rs
+++ b/src/theme/icon.rs
@@ -162,7 +162,6 @@ impl IconTheme {
             ("doc", "\u{f02d}"),                // ""
             ("documents", "\u{f02d}"),          // ""
             (".doom.d", "\u{e779}"),            // ""
-            ("downloads", "\u{f498}"),          // ""
             (".ds_store", "\u{f179}"),          // ""
             (".editorconfig", "\u{e615}"),      // ""
             (".emacs.d", "\u{e779}"),           // ""


### PR DESCRIPTION
I have a Samba share named "Downloads" and it doesn't contain any executable files so this restores the default directory icon.