### PR TITLE
:sparkles: add disable option for permission

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -69,7 +69,7 @@ pub struct Cli {
     pub directory_only: bool,
 
     /// How to display permissions [default: rwx]
-    #[arg(long, value_name = "MODE", value_parser = ["rwx", "octal"])]
+    #[arg(long, value_name = "MODE", value_parser = ["rwx", "octal", "disable"])]
     pub permission: Option<String>,
 
     /// How to display size [default: default]

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,3 +1,5 @@
+//! This module provides methods to handle the program's config files and
+//! operations related to this.
 use crate::flags::display::Display;
 use crate::flags::icons::{IconOption, IconTheme};
 use crate::flags::layout::Layout;
@@ -6,8 +8,6 @@ use crate::flags::size::SizeFlag;
 use crate::flags::sorting::{DirGrouping, SortColumn};
 use crate::flags::HyperlinkOption;
 use crate::flags::{ColorOption, ThemeOption};
-///! This module provides methods to handle the program's config files and operations related to
-///! this.
 use crate::print_error;
 
 use std::path::{Path, PathBuf};

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,8 @@
 use crate::color::Colors;
 use crate::display;
 use crate::flags::{
-    ColorOption, Display, Flags, HyperlinkOption, Layout, Literal, SortOrder, PermissionFlag, ThemeOption,
+    ColorOption, Display, Flags, HyperlinkOption, Layout, Literal, PermissionFlag, SortOrder,
+    ThemeOption,
 };
 use crate::git::GitCache;
 use crate::icon::Icons;
@@ -105,17 +106,18 @@ impl Core {
         };
 
         for path in paths {
-            let mut meta =
-                match Meta::from_path(&path,
-                    self.flags.dereference.0,
-                    self.flags.permission == PermissionFlag::Disable) {
-                        Ok(meta) => meta,
-                        Err(err) => {
-                            print_error!("{}: {}.", path.display(), err);
-                            exit_code.set_if_greater(ExitCode::MajorIssue);
-                            continue;
-                        }
-                };
+            let mut meta = match Meta::from_path(
+                &path,
+                self.flags.dereference.0,
+                self.flags.permission == PermissionFlag::Disable,
+            ) {
+                Ok(meta) => meta,
+                Err(err) => {
+                    print_error!("{}: {}.", path.display(), err);
+                    exit_code.set_if_greater(ExitCode::MajorIssue);
+                    continue;
+                }
+            };
 
             let cache = if self.flags.blocks.0.contains(&Block::GitStatus) {
                 Some(GitCache::new(&path))

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,7 @@
 use crate::color::Colors;
 use crate::display;
 use crate::flags::{
-    ColorOption, Display, Flags, HyperlinkOption, Layout, Literal, SortOrder, ThemeOption,
+    ColorOption, Display, Flags, HyperlinkOption, Layout, Literal, SortOrder, PermissionFlag, ThemeOption,
 };
 use crate::git::GitCache;
 use crate::icon::Icons;
@@ -105,14 +105,17 @@ impl Core {
         };
 
         for path in paths {
-            let mut meta = match Meta::from_path(&path, self.flags.dereference.0) {
-                Ok(meta) => meta,
-                Err(err) => {
-                    print_error!("{}: {}.", path.display(), err);
-                    exit_code.set_if_greater(ExitCode::MajorIssue);
-                    continue;
-                }
-            };
+            let mut meta =
+                match Meta::from_path(&path,
+                    self.flags.dereference.0,
+                    self.flags.permission == PermissionFlag::Disable) {
+                        Ok(meta) => meta,
+                        Err(err) => {
+                            print_error!("{}: {}.", path.display(), err);
+                            exit_code.set_if_greater(ExitCode::MajorIssue);
+                            continue;
+                        }
+                };
 
             let cache = if self.flags.blocks.0.contains(&Block::GitStatus) {
                 Some(GitCache::new(&path))

--- a/src/display.rs
+++ b/src/display.rs
@@ -683,7 +683,7 @@ mod tests {
         dir.child("one.d").create_dir_all().unwrap();
         dir.child("one.d/two").touch().unwrap();
         dir.child("one.d/.hidden").touch().unwrap();
-        let mut metas = Meta::from_path(Path::new(dir.path()), false)
+        let mut metas = Meta::from_path(Path::new(dir.path()), false, false)
             .unwrap()
             .recurse_into(42, &flags, None)
             .unwrap()
@@ -716,7 +716,7 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("dir").create_dir_all().unwrap();
         dir.child("dir/file").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let metas = Meta::from_path(Path::new(dir.path()), false, false)
             .unwrap()
             .recurse_into(42, &flags, None)
             .unwrap()
@@ -757,7 +757,7 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("dir").create_dir_all().unwrap();
         dir.child("dir/file").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let metas = Meta::from_path(Path::new(dir.path()), false, false)
             .unwrap()
             .recurse_into(42, &flags, None)
             .unwrap()
@@ -797,7 +797,7 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("one.d").create_dir_all().unwrap();
         dir.child("one.d/two").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let metas = Meta::from_path(Path::new(dir.path()), false, false)
             .unwrap()
             .recurse_into(42, &flags, None)
             .unwrap()
@@ -828,7 +828,7 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("testdir").create_dir_all().unwrap();
         dir.child("test").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let metas = Meta::from_path(Path::new(dir.path()), false, false)
             .unwrap()
             .recurse_into(1, &flags, None)
             .unwrap()
@@ -862,7 +862,7 @@ mod tests {
 
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("testdir").create_dir_all().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let metas = Meta::from_path(Path::new(dir.path()), false, false)
             .unwrap()
             .recurse_into(1, &flags, None)
             .unwrap()
@@ -892,11 +892,11 @@ mod tests {
 
         let file_path = tmp_dir.path().join("file");
         std::fs::File::create(&file_path).expect("failed to create the file");
-        let file = Meta::from_path(&file_path, false).unwrap();
+        let file = Meta::from_path(&file_path, false, false).unwrap();
 
         let dir_path = tmp_dir.path().join("dir");
         std::fs::create_dir(&dir_path).expect("failed to create the dir");
-        let dir = Meta::from_path(&dir_path, false).unwrap();
+        let dir = Meta::from_path(&dir_path, false, false).unwrap();
 
         assert_eq!(
             display_folder_path(&dir),
@@ -942,15 +942,15 @@ mod tests {
 
         let file_path = tmp_dir.path().join("file");
         std::fs::File::create(&file_path).expect("failed to create the file");
-        let file = Meta::from_path(&file_path, false).unwrap();
+        let file = Meta::from_path(&file_path, false, false).unwrap();
 
         let dir_path = tmp_dir.path().join("dir");
         std::fs::create_dir(&dir_path).expect("failed to create the dir");
-        let dir = Meta::from_path(&dir_path, false).unwrap();
+        let dir = Meta::from_path(&dir_path, false, false).unwrap();
 
         let link_path = tmp_dir.path().join("link");
         std::os::unix::fs::symlink("dir", &link_path).unwrap();
-        let link = Meta::from_path(&link_path, false).unwrap();
+        let link = Meta::from_path(&link_path, false, false).unwrap();
 
         let grid_flags = Flags {
             layout: Layout::Grid,

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -350,7 +350,7 @@ mod test_blocks {
     fn test_from_cli_none() {
         let argv = ["lsd"];
         let cli = Cli::try_parse_from(argv).unwrap();
-        assert!(matches!(Blocks::from_cli(&cli), None));
+        assert!(Blocks::from_cli(&cli).is_none());
     }
 
     #[test]

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -153,14 +153,11 @@ mod test {
     fn test_from_cli_none() {
         let argv = ["lsd"];
         let cli = Cli::try_parse_from(argv).unwrap();
-        assert!(matches!(IgnoreGlobs::from_cli(&cli), None));
+        assert!(IgnoreGlobs::from_cli(&cli).is_none());
     }
 
     #[test]
     fn test_from_config_none() {
-        assert!(matches!(
-            IgnoreGlobs::from_config(&Config::with_none()),
-            None
-        ));
+        assert!(IgnoreGlobs::from_config(&Config::with_none()).is_none());
     }
 }

--- a/src/flags/permission.rs
+++ b/src/flags/permission.rs
@@ -17,6 +17,8 @@ pub enum PermissionFlag {
     Rwx,
     /// The variant to show file permissions in octal format
     Octal,
+    /// Disable the display of owner and permissions, may be used to speed up in Windows
+    Disable,
 }
 
 impl PermissionFlag {
@@ -24,6 +26,7 @@ impl PermissionFlag {
         match value {
             "rwx" => Self::Rwx,
             "octal" => Self::Octal,
+            "disable" => Self::Disable,
             // Invalid value should be handled by `clap` when building an `Cli`
             other => unreachable!("Invalid value '{other}' for 'permission'"),
         }

--- a/src/flags/permission.rs
+++ b/src/flags/permission.rs
@@ -100,6 +100,16 @@ mod test {
     }
 
     #[test]
+    fn test_from_cli_permissions_disable() {
+        let argv = ["lsd", "--permission", "disable"];
+        let cli = Cli::try_parse_from(argv).unwrap();
+        assert_eq!(
+            Some(PermissionFlag::Disable),
+            PermissionFlag::from_cli(&cli)
+        );
+    }
+
+    #[test]
     #[should_panic]
     fn test_from_cli_unknown() {
         let argv = ["lsd", "--permission", "unknown"];

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -162,7 +162,7 @@ mod test {
     fn test_depth_from_cli_empty() {
         let argv = ["lsd"];
         let cli = Cli::try_parse_from(argv).unwrap();
-        assert!(matches!(cli.depth, None));
+        assert!(cli.depth.is_none());
     }
 
     #[test]

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -85,7 +85,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icons = Icons::new(true, IconOption::Never, FlagTheme::Fancy, " ".to_string());
         let icon = icons.get(&meta.name);
@@ -97,7 +97,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icons = Icons::new(false, IconOption::Never, FlagTheme::Fancy, " ".to_string());
         let icon = icons.get(&meta.name);
@@ -110,7 +110,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icons = Icons::new(false, IconOption::Auto, FlagTheme::Fancy, " ".to_string());
         let icon = icons.get(&meta.name);
@@ -122,7 +122,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icons = Icons::new(true, IconOption::Auto, FlagTheme::Fancy, " ".to_string());
         let icon = icons.get(&meta.name);
@@ -135,7 +135,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icon = Icons::new(true, IconOption::Always, FlagTheme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -148,7 +148,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icon = Icons::new(false, IconOption::Always, FlagTheme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -161,7 +161,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let icon = Icons::new(
             false,
@@ -178,7 +178,7 @@ mod test {
     fn get_icon_default_directory() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(file_path, false).unwrap();
+        let meta = Meta::from_path(file_path, false, false).unwrap();
 
         let icon = Icons::new(false, IconOption::Always, FlagTheme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -190,7 +190,7 @@ mod test {
     fn get_icon_default_directory_unicode() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(file_path, false).unwrap();
+        let meta = Meta::from_path(file_path, false, false).unwrap();
 
         let icon = Icons::new(
             false,
@@ -210,7 +210,7 @@ mod test {
         for (file_name, file_icon) in &IconTheme::get_default_icons_by_name() {
             let file_path = tmp_dir.path().join(file_name);
             File::create(&file_path).expect("failed to create file");
-            let meta = Meta::from_path(&file_path, false).unwrap();
+            let meta = Meta::from_path(&file_path, false, false).unwrap();
 
             let icon = Icons::new(false, IconOption::Always, FlagTheme::Fancy, " ".to_string());
             let icon_str = icon.get(&meta.name);
@@ -226,7 +226,7 @@ mod test {
         for (ext, file_icon) in &IconTheme::get_default_icons_by_extension() {
             let file_path = tmp_dir.path().join(format!("file.{ext}"));
             File::create(&file_path).expect("failed to create file");
-            let meta = Meta::from_path(&file_path, false).unwrap();
+            let meta = Meta::from_path(&file_path, false, false).unwrap();
 
             let icon = Icons::new(false, IconOption::Always, FlagTheme::Fancy, " ".to_string());
             let icon_str = icon.get(&meta.name);

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -144,7 +144,7 @@ mod test {
     fn test_dir_type() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         #[cfg(not(windows))]
-        let meta = crate::meta::Meta::from_path(tmp_dir.path(), false)
+        let meta = crate::meta::Meta::from_path(tmp_dir.path(), false, false)
             .expect("failed to get tempdir path");
         let metadata = tmp_dir.path().metadata().expect("failed to get metas");
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -274,7 +274,7 @@ mod test {
         // Create the directory
         let dir_path = tmp_dir.path().join("directory");
         fs::create_dir(&dir_path).expect("failed to create the dir");
-        let meta = Meta::from_path(&dir_path, false).unwrap();
+        let meta = Meta::from_path(&dir_path, false, false).unwrap();
 
         let colors = Colors::new(color::ThemeOption::NoLscolors);
 
@@ -398,7 +398,7 @@ mod test {
         // Create the file;
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let colors = Colors::new(color::ThemeOption::NoColor);
 
@@ -424,7 +424,7 @@ mod test {
         // Create the file;
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, false).unwrap();
 
         let colors = Colors::new(color::ThemeOption::NoColor);
 

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -16,6 +16,15 @@ impl Owner {
     }
 }
 
+impl Default for Owner {
+    fn default() -> Owner {
+        Owner {
+            user: String::from("-"),
+            group: String::from("-"),
+        }
+    }
+}
+
 #[cfg(unix)]
 impl From<&Metadata> for Owner {
     fn from(meta: &Metadata) -> Self {

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -54,6 +54,25 @@ impl From<&Metadata> for Permissions {
     }
 }
 
+impl Default for Permissions {
+    fn default() -> Permissions {
+        Permissions {
+            user_read: false,
+            user_write: false,
+            user_execute: false,
+            group_read: false,
+            group_write: false,
+            group_execute: false,
+            other_read: false,
+            other_write: false,
+            other_execute: false,
+            sticky: false,
+            setgid: false,
+            setuid: false,
+        }
+    }
+}
+
 impl Permissions {
     fn bits_to_octal(r: bool, w: bool, x: bool) -> u8 {
         (r as u8) * 4 + (w as u8) * 2 + (x as u8)
@@ -122,6 +141,7 @@ impl Permissions {
 
                 colors.colorize(octals, &Elem::Octal).to_string()
             }
+            PermissionFlag::Disable => colors.colorize('-', &Elem::NoAccess).to_string(),
         };
 
         ColoredString::new(Colors::default_style(), res)

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -93,12 +93,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("zzz");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("aaa");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::First;
@@ -121,12 +121,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("zzz");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("aaa");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::Last;
@@ -147,12 +147,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("aaa");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("zzz");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::None;
@@ -175,12 +175,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("zzz");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("aaa");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::None;
@@ -203,7 +203,7 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("aaa");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         // Create the file;
         let path_z = tmp_dir.path().join("zzz");
@@ -229,7 +229,7 @@ mod tests {
             .success();
 
         assert!(success, "failed to change file timestamp");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::Time;
@@ -251,22 +251,22 @@ mod tests {
         // Create the file with rs extension;
         let path_a = tmp_dir.path().join("aaa.rs");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         // Create the file with rs extension;
         let path_z = tmp_dir.path().join("zzz.rs");
         File::create(&path_z).expect("failed to create file");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, false).expect("failed to get meta");
 
         // Create the file with js extension;
         let path_j = tmp_dir.path().join("zzz.js");
         File::create(&path_j).expect("failed to create file");
-        let meta_j = Meta::from_path(&path_j, false).expect("failed to get meta");
+        let meta_j = Meta::from_path(&path_j, false, false).expect("failed to get meta");
 
         // Create the file with txt extension;
         let path_t = tmp_dir.path().join("zzz.txt");
         File::create(&path_t).expect("failed to create file");
-        let meta_t = Meta::from_path(&path_t, false).expect("failed to get meta");
+        let meta_t = Meta::from_path(&path_t, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::Extension;
@@ -288,15 +288,15 @@ mod tests {
 
         let path_a = tmp_dir.path().join("2");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         let path_b = tmp_dir.path().join("11");
         File::create(&path_b).expect("failed to create file");
-        let meta_b = Meta::from_path(&path_b, false).expect("failed to get meta");
+        let meta_b = Meta::from_path(&path_b, false, false).expect("failed to get meta");
 
         let path_c = tmp_dir.path().join("12");
         File::create(&path_c).expect("failed to create file");
-        let meta_c = Meta::from_path(&path_c, false).expect("failed to get meta");
+        let meta_c = Meta::from_path(&path_c, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::Version;
@@ -314,19 +314,19 @@ mod tests {
 
         let path_a = tmp_dir.path().join("aaa.aa");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         let path_b = tmp_dir.path().join("aaa");
         create_dir(&path_b).expect("failed to create dir");
-        let meta_b = Meta::from_path(&path_b, false).expect("failed to get meta");
+        let meta_b = Meta::from_path(&path_b, false, false).expect("failed to get meta");
 
         let path_c = tmp_dir.path().join("zzz.zz");
         File::create(&path_c).expect("failed to create file");
-        let meta_c = Meta::from_path(&path_c, false).expect("failed to get meta");
+        let meta_c = Meta::from_path(&path_c, false, false).expect("failed to get meta");
 
         let path_d = tmp_dir.path().join("zzz");
         create_dir(&path_d).expect("failed to create dir");
-        let meta_d = Meta::from_path(&path_d, false).expect("failed to get meta");
+        let meta_d = Meta::from_path(&path_d, false, false).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::None;
@@ -359,14 +359,14 @@ mod tests {
             .expect("failed to create file")
             .write_all(b"1, 2, 3")
             .expect("failed to write to file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, false).expect("failed to get meta");
 
         let path_b = tmp_dir.path().join("bbb.bb");
         File::create(&path_b)
             .expect("failed to create file")
             .write_all(b"1, 2, 3, 4, 5, 6, 7, 8, 9, 10")
             .expect("failed to write file");
-        let meta_b = Meta::from_path(&path_b, false).expect("failed to get meta");
+        let meta_b = Meta::from_path(&path_b, false, false).expect("failed to get meta");
 
         let path_c = tmp_dir.path().join("ccc.cc");
         let path_d = tmp_dir.path().join("ddd.dd");
@@ -381,7 +381,7 @@ mod tests {
         std::os::windows::fs::symlink_file(&path_d, &path_c)
             .expect("failed to create broken symlink");
 
-        let meta_c = Meta::from_path(&path_c, true).expect("failed to get meta");
+        let meta_c = Meta::from_path(&path_c, true, false).expect("failed to get meta");
 
         assert_eq!(by_size(&meta_a, &meta_a), Ordering::Equal);
         assert_eq!(by_size(&meta_a, &meta_b), Ordering::Greater);

--- a/src/theme/color.rs
+++ b/src/theme/color.rs
@@ -1,5 +1,5 @@
-///! This module provides methods to create theme from files and operations related to
-///! this.
+//! This module provides methods to create theme from files and operations related to
+//! this.
 use crossterm::style::Color;
 use serde::{de::IntoDeserializer, Deserialize};
 use std::fmt;

--- a/src/theme/icon.rs
+++ b/src/theme/icon.rs
@@ -18,7 +18,7 @@ where
         ByFilename::Extension => IconTheme::get_default_icons_by_extension(),
     };
     HashMap::<_, _>::deserialize(deserializer)
-        .map(|input| default.into_iter().chain(input.into_iter()).collect())
+        .map(|input| default.into_iter().chain(input).collect())
 }
 
 fn deserialize_by_name<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>


### PR DESCRIPTION
<!--- PR Description --->

add an option for `permission` args to disable the detection of owner and permission,
it may be used in Windows to speed up.

a temporary fix for https://github.com/lsd-rs/lsd/issues/200

this is a POC or RFC, any comment is welcome!

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)