### PR TITLE
Add windows-acl-permissions feature to fix perf issue on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ serial_test = "0.5"
 default = ["git2"]
 sudo = []
 no-git = [] # force disabling git even if available by default
+windows-acl-permissions = []
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Attempted fix for performance issue mentioned in https://github.com/lsd-rs/lsd/issues/200, for machines on a domain.

## Benchmark
For a folder with 50 items.

Before change:
`lsd` took ~40 seconds

After change: 
```pwsh
❯ hyperfine "lsd" --runs 50
Benchmark 1: lsd
  Time (mean ± σ):      39.4 ms ±   8.3 ms    [User: 0.6 ms, System: 0.6 ms]
  Range (min … max):    33.6 ms …  91.8 ms    50 runs
```

## Other notes
I think it makes more sense for this to be disabled by default on windows due to performance, but I could be swayed.
My suggestion would be to use https://github.com/lsd-rs/lsd/issues/866#issuecomment-1721012397 as the default windows permissions behaviour.

P.S thanks for this great tool 🎉

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests (Not applicable imo)
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)