### PR TITLE
Improve sensitivity of last two integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -758,8 +758,8 @@ fn test_date_custom_format_supports_padding() {
 #[test]
 fn test_all_directory() {
     let dir = tempdir();
-    dir.child("one").touch().unwrap();
-    dir.child("two").touch().unwrap();
+    dir.child("subdir-one").touch().unwrap();
+    dir.child("subdir-two").touch().unwrap();
 
     cmd()
         .arg("-a")
@@ -767,7 +767,8 @@ fn test_all_directory() {
         .arg("--ignore-config")
         .arg(dir.path())
         .assert()
-        .stdout(predicate::str::is_match(".").unwrap());
+        .stdout(predicate::str::contains("subdir-one").not())
+        .stdout(predicate::str::contains("subdir-two").not());
 }
 
 #[test]
@@ -777,8 +778,10 @@ fn test_multiple_files() {
     dir.child("two").touch().unwrap();
 
     cmd()
+        .arg("--ignore-config")
         .arg(dir.path().join("one"))
         .arg(dir.path().join("two"))
         .assert()
-        .stdout(predicate::str::is_match(".").unwrap());
+        .stdout(predicate::str::is_match("one").unwrap().count(1))
+        .stdout(predicate::str::is_match("two").unwrap().count(1));
 }


### PR DESCRIPTION
Those tests were only checking that the output was nonempty, so they would pretty much never detect anything fishy. We could go further but it's nontrivial because the output is nondeterministic (because of temporary files) and it's unclear if we want to build complex regexes in the test suite right now. In the meantime, here's a basic improvement.

---
#### TODO

- [x] Use `cargo fmt`
- [ ] ~~Add necessary tests~~
- [ ] ~~Add changelog entry~~
- [ ] ~~Update default config/theme in README (if applicable)~~
- [ ] ~~Update man page at lsd/doc/lsd.md (if applicable)~~