### PR TITLE
human readable flag (-h) enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+- Human readable size flag `-h` re-enabled. [sdorr0](https://github.com/sdorr0)
+
 ## [v1.0.0] - 2023-08-25
 
 ### Added

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -45,7 +45,7 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 : Prints help information
 
 `-h`, `--human-readable`
-: For ls compatibility purposes ONLY, currently set by default
+: Use the `default` display size to show sizes as e.g., 1.7 KB, 3.0 GB, etc.
 
 `--ignore-config`
 : Ignore the configuration file

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,7 +54,7 @@ pub struct Cli {
 
     /// For ls compatibility purposes ONLY, currently set by default
     #[arg(short, long)]
-    human_readable: bool,
+    pub human_readable: bool,
 
     /// Recurse into directories and present the result as a tree
     #[arg(long)]

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -41,7 +41,7 @@ impl Configurable<Self> for SizeFlag {
     /// [None].
     fn from_cli(cli: &Cli) -> Option<Self> {
         if cli.human_readable {
-            return Some(Self::Default)
+            return Some(Self::Default);
         }
         if cli.classic {
             Some(Self::Bytes)

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -27,6 +27,7 @@ impl SizeFlag {
             "default" => Self::Default,
             "short" => Self::Short,
             "bytes" => Self::Bytes,
+            "h" => Self::Default,
             // Invalid value should be handled by `clap` when building an `Cli`
             other => unreachable!("Invalid value '{other}' for 'size'"),
         }
@@ -40,6 +41,9 @@ impl Configurable<Self> for SizeFlag {
     /// `SizeFlag` variant is returned in a [Some]. If neither of them is passed, this returns
     /// [None].
     fn from_cli(cli: &Cli) -> Option<Self> {
+        if cli.human_readable {
+            return Some(Self::Default)
+        }
         if cli.classic {
             Some(Self::Bytes)
         } else {

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -27,7 +27,6 @@ impl SizeFlag {
             "default" => Self::Default,
             "short" => Self::Short,
             "bytes" => Self::Bytes,
-            "h" => Self::Default,
             // Invalid value should be handled by `clap` when building an `Cli`
             other => unreachable!("Invalid value '{other}' for 'size'"),
         }


### PR DESCRIPTION
This re-enables a quick, easy to type command line flag that `ls` users are familiar with for convenience.

In the event a user has changed the default configuration of `lsd` to use a size setting of something other than `default`, this lets a user use the historically established CLI flag (`-h`) to enable the human readable option without having to type `--size=default` on the command line.

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)