### PR TITLE
master

### DIFF
--- a/src/theme/icon.rs
+++ b/src/theme/icon.rs
@@ -341,7 +341,7 @@ impl IconTheme {
             ("avi", "\u{f008}"),             // ""
             ("avro", "\u{e60b}"),            // ""
             ("awk", "\u{f489}"),             // ""
-            ("bak", "\u{f006f}"),            // "󰁯"
+            ("bak", "\u{f016}"),             // ""
             ("bash_history", "\u{f489}"),    // ""
             ("bash_profile", "\u{f489}"),    // ""
             ("bashrc", "\u{f489}"),          // ""


### PR DESCRIPTION
- Added new `custom` option for color config, marked themes folder as deprecated. (#851)
- Updated documentation to include SHELL_COMPLETIONS_DIR (#861)
- Added complete color theming support for Git (#852)
- fix version sort for matching GNU ls (#843)
- Added newlines to warning message (#869)
- Update src/theme/icon.rs to add Svelte icon
- :sparkles: ci: add aarch64 darwin build target and skip on test
- :tada: :memo: update docs, release v1.0.0
- Fix a broken parenthesis in CHANGELOG
- Parse hex colors in themes (#647)
- Update repository names in README.md
- Update README for installation on OpenBSD
- Add configuration and CLI options: truncate owner
- Add support for --literal flag and literal entry in config (#900)
- :sparkles: add disable option for permission
- :mag: :hammer: fix test for adding disable permission
- Add changelog deprecation notice (#907)
- Make .bak (backup) files have a regular file icon
