### PR TITLE
upgrade xattr to version 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libgit2-sys"
@@ -1465,9 +1465,9 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "xattr"
-version = "0.2.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ git2 = { version = "0.16", optional = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11.*"
-xattr = "0.2.*"
+xattr = "1"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Memory"] }


### PR DESCRIPTION
Upgrade xattr to version 1 to get it closer to what we have in Debian.

ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/lsd/debian/patches/update-xattr.diff

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
