### PR TITLE
upgrade lscolors to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "assert_cmd"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +533,9 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.9.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9323b3525d4efad2dead1837a105e313253bfdbad1d470994038eededa4d62"
-dependencies = [
- "ansi_term",
-]
+checksum = "18a9df1d1fb6d9e92fa043e9eb9a3ecf6892c7b542bae5137cd1e419e40aa8bf"
 
 [[package]]
 name = "lsd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1.17.1"
 chrono = { version = "0.4.*", features = ["unstable-locales"] }
 chrono-humanize = "0.1.*"
 unicode-width = "0.1.*"
-lscolors = "0.9.0"
+lscolors = "0.14.0"
 wild = "2.0.*"
 globset = "0.4.*"
 xdg = "2.1.*"


### PR DESCRIPTION
upgrade lscolors to 0.14.0 to get it closer to what we have in Debian.

ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/lsd/debian/patches/relax-deps.patch#L59
---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
