### PR TITLE
fix typo in link color table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/theme/color.rs
+++ b/src/theme/color.rs
@@ -78,7 +78,7 @@ where
 }
 
 /// A struct holding the theme configuration
-/// Color table: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.avg
+/// Color table: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
<!--- PR Description --->
This PR simply fixes a typo I noticed in the `theme/color.rs` file. It appears to attempt to link to a `.svg` but used `.avg`.
---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
