### PR TITLE
⬆️ bump lscolors to v0.15.0 and msrv to 1.69.0

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,7 +6,7 @@ env:
   PROJECT_NAME: lsd
   PROJECT_DESC: "An ls command with a lot of pretty colors."
   PROJECT_AUTH: "Peltoche <peltoche@halium.fr>"
-  RUST_MIN_SRV: "1.64.0"
+  RUST_MIN_SRV: "1.69.0"
 
 on: [push, pull_request]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a9df1d1fb6d9e92fa043e9eb9a3ecf6892c7b542bae5137cd1e419e40aa8bf"
+checksum = "bf7015a04103ad78abb77e4b79ed151e767922d1cfde5f62640471c629a2320d"
 
 [[package]]
 name = "lsd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1.17.1"
 chrono = { version = "0.4.*", features = ["unstable-locales"] }
 chrono-humanize = "0.1.*"
 unicode-width = "0.1.*"
-lscolors = "0.14.0"
+lscolors = "0.15.0"
 wild = "2.0.*"
 globset = "0.4.*"
 xdg = "2.1.*"

--- a/build.rs
+++ b/build.rs
@@ -16,8 +16,8 @@ include!("src/app.rs");
 
 fn main() {
     // rustc version too small or can't figure it out
-    if version_check::is_min_version("1.64.0") != Some(true) {
-        eprintln!("'lsd' requires rustc >= 1.64.0");
+    if version_check::is_min_version("1.69.0") != Some(true) {
+        eprintln!("'lsd' requires rustc >= 1.69.0");
         exit(1);
     }
 

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -386,7 +386,7 @@ mod tests {
         // likely to fail because of permission issue
         // see https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
         #[cfg(windows)]
-        std::os::windows::fs::symlink_file(&path_c, &path_b)
+        std::os::windows::fs::symlink_file(path_c, &path_b)
             .expect("failed to create broken symlink");
 
         let meta_b = Meta::from_path(&path_b, true, false).expect("failed to get meta");

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -378,7 +378,7 @@ mod tests {
         // likely to fail because of permission issue
         // see https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
         #[cfg(windows)]
-        std::os::windows::fs::symlink_file(&path_d, &path_c)
+        std::os::windows::fs::symlink_file(path_d, &path_c)
             .expect("failed to create broken symlink");
 
         let meta_c = Meta::from_path(&path_c, true, false).expect("failed to get meta");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -303,7 +303,7 @@ fn test_dereference_link_broken_link_output() {
     // likely to fail because of permission issue
     // see https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
     #[cfg(windows)]
-    std::os::windows::fs::symlink_file(&target, &link).expect("failed to create broken symlink");
+    std::os::windows::fs::symlink_file(target, &link).expect("failed to create broken symlink");
 
     cmd()
         .arg("-l")


### PR DESCRIPTION
<!--- PR Description --->

predicates v3 msrv is 1.69 in https://github.com/lsd-rs/lsd/pull/938

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
