### PR TITLE
Improve theme error informations

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -176,7 +176,10 @@ impl Colors {
             ThemeOption::Default | ThemeOption::NoLscolors => Some(Theme::default().color),
             ThemeOption::Custom => Some(
                 Theme::from_path::<ColorTheme>(Path::new("colors").to_str().unwrap())
-                    .unwrap_or_default(),
+                    .unwrap_or_else(|e| {
+                        print_output!("Warning: cannot load custom theme. {}.\n\n", e);
+                        ColorTheme::default()
+                    }),
             ),
             ThemeOption::CustomLegacy(ref file) => {
                 print_output!(

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -68,6 +68,7 @@ impl Theme {
                     Ok(t) => return Ok(t),
                     Err(e) => {
                         err = Error::from(e);
+                        break;
                     }
                 },
                 Err(e) => err = Error::from(e),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -131,10 +131,8 @@ mod tests {
 
         // There are many reasons why we could get an IoError, not just "file not found".
         // Here we test that we actually get informations about the underlying io error.
-        assert_eq!(
-            "Cannot read theme file. No such file or directory (os error 2)".to_string(),
-            the_error.to_string()
-        );
+        assert!(the_error.to_string().starts_with("Cannot read theme file"));
+        assert!(the_error.to_string().ends_with("(os error 2)"));
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -27,11 +27,11 @@ pub struct Theme {
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Theme file not existed")]
+    #[error("Cannot read theme file. {0}")]
     NotExisted(#[from] io::Error),
-    #[error("Theme file format invalid")]
+    #[error("Theme file format invalid. {0}")]
     InvalidFormat(#[from] serde_yaml::Error),
-    #[error("Theme file path invalid {0}")]
+    #[error("Theme file path invalid. {0}")]
     InvalidPath(String),
     #[error("Unknown Theme error")]
     Unknown(),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -147,7 +147,7 @@ mod tests {
         let theme = dir.path().join("does-not-exist.yaml");
         let mut file = File::create(&theme).unwrap();
         // Write a purposefully bogus file
-        writeln!(file, "{}", "bogus-field: 1").unwrap();
+        writeln!(file, "bogus-field: 1").unwrap();
 
         let res = Theme::from_path::<ColorTheme>(theme.to_str().unwrap());
         assert!(res.is_err());


### PR DESCRIPTION
I couldn't figure out why my local changes to the theme colors definition were not being picked up, so I went to the source.
Turned out my yaml file was using some improper fields.

This PR does:
- print a specific warning if in the config `color.theme` was set to custom and no `colors.yaml` (or `colors.yml`) was found
- print a specific warning if a color theme was found, but the parsing failed, and why it failed.

Contrary to before, if a color file definition exists and it cannot be parsed we immediately switch to the default (plus a warning). The previous logic was hiding format errors if there were other file extensions to try.

Some examples of the output (before regular lsd output):

**if color.y(a)ml is found, but contains wrong data**
```
Warning: cannot load custom theme. Theme file format invalid. date: unknown field `days-old`, expected one of `hour-old`, `day-old`, `older` at line 18 column 3.
```

**if color.theme is set to "custom" in the config file, but no color.y(a)ml is present**

```
Warning: cannot load custom theme. Cannot read theme file. No such file or directory (os error 2).
```

Sidenotes:
- warning output bleed into `cargo test`. This was already happening with `Warning: the 'themes' directory is deprecated, use 'colors.yaml' instead.`, I made it slightly worse. Perhaps in general warnings should be behind `#[cfg(not(test))]` or similar, didn't investigate in `print_error` either, considered it out of scope.
- imho we should accept a specific extension for color.yml and the others. Iterating over extensions produces subtle bugs like this and there are no particular benefits (if the documentation tells you to create <filename.yml>, you create <filename.yml> - now you also get a warning)

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
