### PR TITLE
Update README: Icon Theme config does not require build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,6 @@ Please also notice that an empty theme is **NOT** supported due to
 
 ### Icon Theme
 
-> **NOTE:** This feature is not available in a release yet. You can
-> get this feature by [building from
-> `master`](https://github.com/lsd-rs/lsd#from-source).
-
 Icon theme can be configured in a fixed location, `$XDG_CONFIG_DIR/lsd/icons.yaml`,
 for example, `~/.config/lsd/icons.yaml` on macOS,
 please check [Config file location](#config-file-location) to make sure where is `$XDG_CONFIG_DIR`.


### PR DESCRIPTION
✨ theme: bring icon theme to lsd by @zwpaper in #707 is included in [Release v1.0.0](https://github.com/lsd-rs/lsd/releases/tag/v1.0.0).

