### PR TITLE
Updated README.md to contain clear instructions for color scheming in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,9 @@ alias lt='ls --tree'
 
 ## F.A.Q
 
+### Custom Color Schemes for Windows
+For `lsd` currently, it reads a system environment variable called LS_COLORS. Please look at the marked solution in [this post](https://github.com/orgs/lsd-rs/discussions/958#discussioncomment-7659375), which contains a guide on how to set a color scheme.
+
 ### Icons not showing up
 
 For `lsd` to be able to display icons, the font has to include special font glyphs. This might not be the case for most fonts that you download. Thankfully, you can patch most fonts using [NerdFont](https://www.nerdfonts.com/) and add these icons. Or you can just download an already patched version of your favourite font from [NerdFont font download page](https://www.nerdfonts.com/font-downloads).


### PR DESCRIPTION
When i was trying to configure lsd for Windows, I found it a bit difficult to understand how to configure the color themes. Currently the color.yaml file is unimplemented for Windows, so I have added a section about it in the FAQ for anyone else looking for help.

---
#### TODO

As I have only modified a markdown file, I do not believe I need to do anything in the TODO list.
