### PR TITLE
Remove options from example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,20 +257,6 @@ symlink-arrow: ⇒
 # Whether to display block headers.
 # Possible values: false, true
 header: false
-
-# == Literal ==
-# Whether to show quotes on filenames.
-# Possible values: false, true
-literal: false
-
-# == Truncate owner ==
-# How to truncate the username and group names for a file if they exceed a certain
-# number of characters.
-truncate-owner:
-  # Number of characters to keep. By default, no truncation is done (empty value).
-  after:
-  # String to be appended to a name if truncated.
-  marker: ""
 ```
 
 </details>

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -140,15 +140,6 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 `--header`
 : Display block headers
 
-`-N --literal`
-: Print entry names without quoting
-
-`--truncate-owner-after`
-: Truncate the user and group names if they exceed a certain number of characters
-
-`--truncate-owner-marker`
-: Truncation marker appended to a truncated user or group name
-
 # ARGS
 
 `<FILE>...`


### PR DESCRIPTION
Using the example from the README results in the following error:

````
lsd: Configuration file /home/user/.config/lsd/config.yaml format error, unknown field `literal`, expected one of `classic`, `blocks`, `color`, `date`, `dereference`, `display`, `icons`, `ignore-globs`, `indicators`, `layout`, `recursion`, `size`, `permission`, `sorting`, `no-symlink`, `total-size`, `symlink-arrow`, `hyperlink`, `header` at line 127 column 1.

lsd: Configuration file /home/user/.config/lsd/config.yaml format error, unknown field `truncate-owner`, expected one of `classic`, `blocks`, `color`, `date`, `dereference`, `display`, `icons`, `ignore-globs`, `indicators`, `layout`, `recursion`, `size`, `permission`, `sorting`, `no-symlink`, `total-size`, `symlink-arrow`, `hyperlink`, `header` at line 127 column 1.
````

Tested on Fedora 39 with lsd 1.0.0 installed using cargo.