### PR TITLE
fix: directory name ending with extention are not prepended with ext …

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -45,6 +45,7 @@ impl Icons {
                     FileType::CharDevice => &t.filetype.device_char,
                     FileType::BlockDevice => &t.filetype.device_block,
                     FileType::Special => &t.filetype.special,
+                    FileType::Directory { .. } => &t.filetype.dir,
                     _ => {
                         if let Some(icon) = t.name.get(name.file_name().to_lowercase().as_str()) {
                             icon
@@ -55,7 +56,6 @@ impl Icons {
                             icon
                         } else {
                             match file_type {
-                                FileType::Directory { .. } => &t.filetype.dir,
                                 // If a file has no extension and is executable, show an icon.
                                 // Except for Windows, it marks everything as an executable.
                                 #[cfg(not(windows))]

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -77,7 +77,7 @@ mod test {
     use super::{IconTheme, Icons};
     use crate::flags::{IconOption, IconTheme as FlagTheme};
     use crate::meta::Meta;
-    use std::fs::File;
+    use std::fs::{create_dir_all, File};
     use tempfile::tempdir;
 
     #[test]
@@ -232,6 +232,25 @@ mod test {
             let icon_str = icon.get(&meta.name);
 
             assert_eq!(icon_str, format!("{}{}", file_icon, icon.icon_separator));
+        }
+    }
+
+    #[test]
+    fn directory_icon_consistency() {
+        let tmp_dir = tempdir().expect("failed to create temp dir");
+
+        for (ext, _) in &IconTheme::get_default_icons_by_extension() {
+            let dir_path = tmp_dir.path().join(format!("folder.{ext}"));
+            create_dir_all(&dir_path).expect("failed to create file");
+            let meta = Meta::from_path(&dir_path, false, false).unwrap();
+
+            let icon = Icons::new(false, IconOption::Always, FlagTheme::Fancy, " ".to_string());
+            let icon_str = icon.get(&meta.name);
+
+            assert_eq!(
+                icon_str,
+                format!("{}{}", "\u{f115}" /*  */, icon.icon_separator)
+            );
         }
     }
 }


### PR DESCRIPTION
Tried fixing #965 

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
