### PR TITLE
Windows tilde expansion and multiple config / theme paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of characters (disabled by default).
 - Add support for `--literal` from [PanGan21](https://github.com/PanGan21)
 - Add support for tilde (`~`) expansion on Windows from [Ofer Sadan](https://github.com/ofersadan85)
+- Add support to search multiple paths for config file and theme files from [Ofer Sadan](https://github.com/ofersadan85):
+  - `$XDG_CONFIG_HOME/lsd` or `$HOME/.config/lsd` (in that order) on non-Windows platforms (these are usually the same)
+  - `%APPDATA%\lsd` or `%USERPROFILE%\.config\lsd` (in that order) on Windows
+- Add support for both `config.yaml` and `config.yml` for the config file name from [Ofer Sadan](https://github.com/ofersadan85)
 
 ## [v1.0.0] - 2023-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration fields) to truncate user and group names if they exceed a certain number
   of characters (disabled by default).
 - Add support for `--literal` from [PanGan21](https://github.com/PanGan21)
+- Add support for tilde (`~`) expansion on Windows from [Ofer Sadan](https://github.com/ofersadan85)
 
 ## [v1.0.0] - 2023-08-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,22 +226,23 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -658,7 +659,6 @@ dependencies = [
  "wild",
  "windows",
  "xattr",
- "xdg",
  "yaml-rust",
 ]
 
@@ -726,6 +726,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -1565,12 +1571,6 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version_check = "0.9.*"
 
 [dependencies]
 crossterm = { version = "0.27.0", features = ["serde"] }
-dirs = "4"
+dirs = "5.0.1"
 libc = "0.2.*"
 human-sort = "0.2.2"
 term_grid = "0.1.*"
@@ -37,7 +37,6 @@ unicode-width = "0.1.*"
 lscolors = "0.15.0"
 wild = "2.0"
 globset = "0.4.*"
-xdg = "2.1"
 yaml-rust = "0.4.*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/README.md
+++ b/README.md
@@ -102,16 +102,21 @@ Check [Config file content](#config-file-content) for details.
 
 On non-Windows systems `lsd` follows the
 [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-convention for the location of the configuration file. The configuration dir
-`lsd` uses is itself named `lsd`. In that directory it looks first for a file
-called `config.yaml`.
-For most people it should be enough to put their config file at
-`~/.config/lsd/config.yaml`.
+convention for the location of the configuration file. A `config.yaml` or `config.yml` file will be searched for in these locations, in order:
+
+- `$XDG_CONFIG_HOME/lsd`
+- `$HOME/.config/lsd`
+
+On most systems these are mapped to the same location, which is `~/.config/lsd/config.yaml`.
 
 ### Windows
 
-On Windows systems `lsd` only looks for the `config.yaml` files in one location:
-`%APPDATA%\lsd\`
+On Windows systems `lsd` searches for `config.yaml` or `config.yml` in the following locations, in order:
+
+- `%APPDATA%\lsd`
+- `%USERPROFILE%\.config\lsd`
+
+These are usually something like `C:\Users\username\AppData\Roaming\lsd\config.yaml` and `C:\Users\username\.config\lsd\config.yaml` respectively.
 
 ### Custom
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -19,6 +19,8 @@ use std::os::unix::io::AsRawFd;
 use crate::flags::blocks::Block;
 use crate::git_theme::GitTheme;
 #[cfg(target_os = "windows")]
+use crate::meta::windows_utils;
+#[cfg(target_os = "windows")]
 use terminal_size::terminal_size;
 
 pub struct Core {
@@ -104,6 +106,9 @@ impl Core {
             _ if self.flags.recursion.enabled => self.flags.recursion.depth,
             _ => 1,
         };
+
+        #[cfg(target_os = "windows")]
+        let paths: Vec<PathBuf> = paths.into_iter().map(windows_utils::expand_home).collect();
 
         for path in paths {
             let mut meta = match Meta::from_path(

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ extern crate terminal_size;
 extern crate unicode_width;
 extern crate url;
 extern crate wild;
-extern crate xdg;
 extern crate yaml_rust;
 
 #[cfg(unix)]

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -13,7 +13,7 @@ mod size;
 mod symlink;
 
 #[cfg(windows)]
-mod windows_utils;
+pub mod windows_utils;
 
 pub use self::access_control::AccessControl;
 pub use self::date::Date;

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -2,7 +2,7 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::mem::MaybeUninit;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use windows::Win32::Foundation::PSID;
 use windows::Win32::Security::{self, Authorization::TRUSTEE_W, ACL};
@@ -341,6 +341,18 @@ pub fn is_path_system(path: &Path) -> bool {
         path,
         windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_SYSTEM,
     )
+}
+
+/// Expands the `~` in a path to the current user's home directory
+pub fn expand_home(path: PathBuf) -> PathBuf {
+    if path.starts_with("~") {
+        if let Some(home) = dirs::home_dir() {
+            let mut expanded = home.to_path_buf();
+            expanded.push(path.strip_prefix("~").unwrap());
+            return expanded;
+        }
+    }
+    path
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds some features that I was really missing in `lsd`:
- Tilde (~) expansion on Windows - This is already supported when seaching for theme files, and is also  supported on windows for many other cli apps. Fixes #903
- Multiple config paths: accept both `config.yml` and `config.yaml` as they are both very common (.yml especially on Windows, as most Windows users are used to 3 letter extensions). 
- Multiple config paths (continued) - Support the config file in both `$XDG_CONFIG_HOME/lsd` or `$HOME/.config/lsd` on non-Windows platforms, and both `%APPDATA%\lsd` or `%USERPROFILE%\.config\lsd` on Windows. This is important for consistency with normal dotfiles for other apps. Fixes #758
- Remove dependancy on [xdg](https://docs.rs/xdg/latest/xdg/) as this was unneeded. [dirs](https://docs.rs/dirs/5.0.1/dirs/) already uses `xdg` internally, and using only `dir` is more consistent and reliable for all systems.
- Added support to search theme files in all the same paths that config files are searched for.

#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests - Not needed, these are really simple changes. All current tests pass
- [x] Update default config/theme in README (if applicable) - Not needed
- [x] Update man page at lsd/doc/lsd.md (if applicable) - not needed. Updated the README.md file only
