### PR TITLE
Remove `literal` and `truncate-owner` fields from example readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,20 +258,6 @@ symlink-arrow: ⇒
 # Whether to display block headers.
 # Possible values: false, true
 header: false
-
-# == Literal ==
-# Whether to show quotes on filenames.
-# Possible values: false, true
-literal: false
-
-# == Truncate owner ==
-# How to truncate the username and group names for a file if they exceed a certain
-# number of characters.
-truncate-owner:
-  # Number of characters to keep. By default, no truncation is done (empty value).
-  after:
-  # String to be appended to a name if truncated.
-  marker: ""
 ```
 
 </details>


### PR DESCRIPTION
Hello,
In setting up my `lsd` configuration, I ran into some issues that both the `literal` and `truncate-owner` fields weren't supported in `lsd` version 1.0.0. This commit removes those fields from the example README for future users. Hope that helps!
Warmest,
Olga

```
(base)
 Thu  7 Mar - 10:43  ~ 
  lsd --version
lsd 1.0.0
```

Here are the error messages:

```
(base)
 Thu  7 Mar - 10:42  ~ 
  lsd --config-file ~/.config/lsd/config.yml
lsd: Configuration file /Users/olgabotvinnik/.config/lsd/config.yml format error, unknown field `literal`, expected one of `classic`, `blocks`, `color`, `date`, `dereference`, `display`, `icons`, `ignore-globs`, `indicators`, `layout`, `recursion`, `size`, `permission`, `sorting`, `no-symlink`, `total-size`, `symlink-arrow`, `hyperlink`, `header` at line 141 column 1.

thread 'main' panicked at /Users/olgabotvinnik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lsd-1.0.0/src/main.rs:117:33:
Provided file path is invalid
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
(base)
 ✘  Thu  7 Mar - 10:42  ~ 
  lsd --config-file ~/.config/lsd/config.yml
lsd: Configuration file /Users/olgabotvinnik/.config/lsd/config.yml format error, unknown field `truncate-owner`, expected one of `classic`, `blocks`, `color`, `date`, `dereference`, `display`, `icons`, `ignore-globs`, `indicators`, `layout`, `recursion`, `size`, `permission`, `sorting`, `no-symlink`, `total-size`, `symlink-arrow`, `hyperlink`, `header` at line 146 column 1.

thread 'main' panicked at /Users/olgabotvinnik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lsd-1.0.0/src/main.rs:117:33:
Provided file path is invalid
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


<!--- PR Description --->

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
