### PR TITLE
chore: build with `--locked` flag in CI

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -200,7 +200,7 @@ jobs:
       with:
         use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
         command: build
-        args: --release --target=${{ matrix.job.target }}
+        args: --release --target=${{ matrix.job.target }} --locked
     - name: Test
       if: matrix.job.target != 'aarch64-apple-darwin'
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
```sh
$ cargo build -h

--locked Require Cargo.lock is up to date
```

so that we can catch #1021 before the release :bear:
