### PR TITLE
Disable classify when piped

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,8 @@
 use crate::color::Colors;
 use crate::display;
 use crate::flags::{
-    ColorOption, Display, Flags, HyperlinkOption, Layout, Literal, SortOrder, ThemeOption,
+    ColorOption, Display, Flags, HyperlinkOption, Indicators, Layout, Literal, SortOrder,
+    ThemeOption,
 };
 use crate::git::GitCache;
 use crate::icon::Icons;
@@ -74,6 +75,7 @@ impl Core {
             inner_flags.layout = Layout::OneLine;
 
             flags.literal = Literal(true);
+            flags.display_indicators = Indicators(false);
         };
 
         let sorters = sort::assemble_sorters(&flags);


### PR DESCRIPTION
The `--classify` flag (`indicators` option) is turned on when piped to other commands.
This PR fixes that, disabling `display_indicators` when output is not a TTY. Fixes #918.

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
