### PR TITLE
fix: padding of extra spaces when using '--size=bytes'

### DIFF
--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -73,7 +73,7 @@ impl Size {
             ColoredString::new(Colors::default_style(), left_pad),
             val_content,
         ];
-        if flags.size != SizeFlag::Short {
+        if flags.size == SizeFlag::Default {
             strings.push(ColoredString::new(Colors::default_style(), " ".into()));
         }
         strings.push(unit_content);


### PR DESCRIPTION
<!--- PR Description --->

Before:
<img width="821" alt="image" src="https://github.com/lsd-rs/lsd/assets/17561793/e7fb7f10-fe0d-4f3e-94f2-8fca94e88d52">

After:
<img width="809" alt="image" src="https://github.com/lsd-rs/lsd/assets/17561793/42a054dd-9ea3-4f6b-95e3-3a8afba32d4d">


---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
