### PR TITLE
Fix clap doc-comment

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ pub struct Cli {
     #[arg(value_name = "FILE", default_value = ".", value_hint = ValueHint::AnyPath)]
     pub inputs: Vec<PathBuf>,
 
-    /// Do not ignore entries starting with .
+    /// Do not ignore entries starting with . .
     #[arg(short, long, overrides_with = "almost_all")]
     pub all: bool,
 


### PR DESCRIPTION
clap always removes the last single period from a doc-comment.

<!--- PR Description --->
before:
```console
~$ lsd --help
  -a, --all                          Do not ignore entries starting with
```

after:
```console
~$ lsd --help
  -a, --all                          Do not ignore entries starting with .
```

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
