### PR TITLE
Fixed misaligned outputs and unicode-width dependency version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ sys-locale = "0.3"
 once_cell = "1.17.1"
 chrono = { version = "0.4.19", features = ["unstable-locales"] }
 chrono-humanize = "0.2"
-# unicode-width 0.1.13 has a breaking change so stick to 0.1.11
+# incompatible with v0.1.11
 unicode-width = "0.1.13"
 lscolors = "0.16.0"
 wild = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1.17.1"
 chrono = { version = "0.4.19", features = ["unstable-locales"] }
 chrono-humanize = "0.2"
 # unicode-width 0.1.13 has a breaking change so stick to 0.1.11
-unicode-width = "=0.1.11"
+unicode-width = "0.1.13"
 lscolors = "0.16.0"
 wild = "2.0"
 globset = "0.4.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ sys-locale = "0.3"
 once_cell = "1.17.1"
 chrono = { version = "0.4.19", features = ["unstable-locales"] }
 chrono-humanize = "0.2"
-unicode-width = "0.1.*"
+# unicode-width 0.1.13 has a breaking change so stick to 0.1.11
+unicode-width = "=0.1.11"
 lscolors = "0.16.0"
 wild = "2.0"
 globset = "0.4.*"

--- a/src/display.rs
+++ b/src/display.rs
@@ -457,6 +457,7 @@ fn get_visible_width(input: &str, hyperlink: bool) -> usize {
         }
     }
 
+    // `UnicodeWidthStr::width` counts all unicode characters including escape '\u{1b}' and hyperlink '\x1B'
     UnicodeWidthStr::width(input) - nb_invisible_char
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -440,7 +440,8 @@ fn get_visible_width(input: &str, hyperlink: bool) -> usize {
 
         let m_pos = s.find('m');
         if let Some(len) = m_pos {
-            nb_invisible_char += len
+            // len points to the 'm' character, we must include 'm' to invisible characters
+            nb_invisible_char += len + 1;
         }
     }
 
@@ -450,7 +451,8 @@ fn get_visible_width(input: &str, hyperlink: bool) -> usize {
 
             let m_pos = s.find("\x1B\x5C");
             if let Some(len) = m_pos {
-                nb_invisible_char += len
+                // len points to the '\x1B' character, we must include both '\x1B' and '\x5C' to invisible characters
+                nb_invisible_char += len + 2
             }
         }
     }


### PR DESCRIPTION
<!--- PR Description --->

This could possibly fix misaligned output issues #1063

The problem occured only if when I `cargo install lsd`, not when I build it directly from the clone or install it via `brew`.

This is because of the dependency `unicode-width`'s version. The version installed via `cargo install` was using the latest `unicode-width`, v0.1.13, but others were using v0.1.11 because of `Cargo.lock`.

The dependency `unicode-width` had a [breaking change](https://github.com/unicode-rs/unicode-width/issues/55) between v0.1.11 and v0.1.13 that returns a different result when [counting unicode characters](https://github.com/lsd-rs/lsd/blob/5d02a59e29a755baeb33a546eabfc6914fdedf76/src/display.rs#L458). 

The new behavior in `unicode-width` v0.1.13 is more intuitive for calculating the length of a unicode string, so I fixed the logic accordingly.



---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
