### PR TITLE
Fix hint stating wrong permissions option #1065

### DIFF
--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -308,7 +308,7 @@ impl Meta {
                 ),
                 Err(e) => {
                     eprintln!(
-                        "lsd: {}: {}(Hint: Consider using `--permission disabled`.)",
+                        "lsd: {}: {}(Hint: Consider using `--permission disable`.)",
                         path.to_str().unwrap_or(""),
                         e
                     );


### PR DESCRIPTION
Fixed a hint, that stated the wrong --permissions option.
See issue #1065.

---
#### TODO

- [+] Use `cargo fmt`
- [-] Add necessary tests
- [-] Update default config/theme in README (if applicable)
- [-] Update man page at lsd/doc/lsd.md (if applicable)
