### PR TITLE
Fixed icons alignment of various rendered width

### DIFF
--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -7,6 +7,7 @@ use crate::url::Url;
 use std::cmp::{Ordering, PartialOrd};
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
+use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug)]
 pub enum DisplayOption<'a> {
@@ -147,26 +148,37 @@ impl Name {
         display_option: &DisplayOption,
         hyperlink: HyperlinkOption,
         literal: bool,
+        val_alignment: Option<usize>,
     ) -> ColoredString {
+        let icon_content = icons.get(self);
+        let left_pad = if let Some(align) = val_alignment {
+            " ".repeat(align - UnicodeWidthStr::width(icon_content.as_str()))
+        } else {
+            "".to_string()
+        };
+
         let content = match display_option {
             DisplayOption::FileName => {
                 format!(
-                    "{}{}",
-                    icons.get(self),
+                    "{}{}{}",
+                    left_pad,
+                    icon_content,
                     self.hyperlink(self.escape(self.file_name(), literal), hyperlink)
                 )
             }
             DisplayOption::Relative { base_path } => format!(
-                "{}{}",
-                icons.get(self),
+                "{}{}{}",
+                left_pad,
+                icon_content,
                 self.hyperlink(
                     self.escape(&self.relative_path(base_path).to_string_lossy(), literal),
                     hyperlink
                 )
             ),
             DisplayOption::None => format!(
-                "{}{}",
-                icons.get(self),
+                "{}{}{}",
+                left_pad,
+                icon_content,
                 self.hyperlink(
                     self.escape(&self.path.to_string_lossy(), literal),
                     hyperlink
@@ -261,6 +273,7 @@ mod test {
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
                 true,
+                None,
             )
         );
     }
@@ -284,7 +297,8 @@ mod test {
                 icons,
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
-                true
+                true,
+                None,
             )
         );
     }
@@ -318,7 +332,8 @@ mod test {
                 icons,
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
-                true
+                true,
+                None,
             )
         );
     }
@@ -352,7 +367,8 @@ mod test {
                 &icons,
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
-                true
+                true,
+                None,
             )
         );
     }
@@ -384,7 +400,8 @@ mod test {
                 icons,
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
-                true
+                true,
+                None,
             )
         );
     }
@@ -409,7 +426,8 @@ mod test {
                     &icons,
                     &DisplayOption::FileName,
                     HyperlinkOption::Never,
-                    true
+                    true,
+                    None,
                 )
                 .to_string()
         );
@@ -442,7 +460,8 @@ mod test {
                     &icons,
                     &DisplayOption::FileName,
                     HyperlinkOption::Always,
-                    true
+                    true,
+                    None,
                 )
                 .to_string()
         );
@@ -664,6 +683,7 @@ mod test {
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
                 false,
+                None,
             )
         );
 
@@ -683,6 +703,7 @@ mod test {
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
                 false,
+                None,
             )
         );
 
@@ -702,6 +723,7 @@ mod test {
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
                 false,
+                None,
             )
         );
 
@@ -723,6 +745,7 @@ mod test {
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
                 false,
+                None,
             )
         );
 
@@ -744,6 +767,7 @@ mod test {
                 &DisplayOption::FileName,
                 HyperlinkOption::Never,
                 false,
+                None,
             )
         );
     }


### PR DESCRIPTION
For #1054.

# **Before**
![image](https://github.com/lsd-rs/lsd/assets/15500385/4e4b5cd6-b5f6-405d-a242-bb30a6ce9cef)
![image](https://github.com/lsd-rs/lsd/assets/15500385/cec2538a-0384-4242-bfff-c2ee75980ceb)


# **After**
![image](https://github.com/lsd-rs/lsd/assets/15500385/9e546902-c222-40b9-87b4-e66007ec0751)
![image](https://github.com/lsd-rs/lsd/assets/15500385/8cdedfbb-60cf-46ff-b839-a132f956b012)

I'm not sure if it is OK to force right-align icons, but I think it is the simplest way to do it.

This is the same logic as aligning 'Block::Size' or 'Block::SizeValue'.
But for `--tree`, icons are aligned within same level entries.


---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
