### PR TITLE
Add space for executable construction icon

### DIFF
--- a/src/theme/icon.rs
+++ b/src/theme/icon.rs
@@ -98,7 +98,7 @@ impl ByType {
             file: "\u{1f4c4}".into(),
             pipe: "\u{1f4e9}".into(),
             socket: "\u{1f4ec}".into(),
-            executable: "\u{1f3d7}".into(),
+            executable: "\u{1f3d7} ".into(),
             symlink_dir: "\u{1f5c2}".into(),
             symlink_file: "\u{1f516}".into(),
             device_char: "\u{1f5a8}".into(),


### PR DESCRIPTION
Continuation of #1056, which was closed due to incorrect branch. We should find a way to dynamically calculate the size so we don't have to go around adding spaces like this.

Makes executable files go from looking like this:
![image](https://github.com/lsd-rs/lsd/assets/30786211/a279c5d1-ada0-49d5-ab1c-b6136654d4e4)

To this:
![image](https://github.com/lsd-rs/lsd/assets/30786211/d33e38ad-0d73-4cc7-a908-c83416221078)

Notice in the original image there's no spacing between the construction crane icon and the file's name.

---
#### TODO

- [X] Use `cargo fmt`
- [X] Add necessary tests
- [X] Update default config/theme in README (if applicable)
- [X] Update man page at lsd/doc/lsd.md (if applicable)
