### PR TITLE
docs: Remove stray quote in git flag documentation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -154,7 +154,7 @@ pub struct Cli {
     #[arg(short, long)]
     pub inode: bool,
 
-    /// Show git status on file and directory"
+    /// Show git status on file and directory
     /// Only when used with --long option
     #[arg(short, long)]
     pub git: bool,


### PR DESCRIPTION
<!--- PR Description --->
Remove an extra double quote character from the documentation comment for the git (-g, --git) option
---
#### TODO

- [x] Use `cargo fmt`
- [N/A] Add necessary tests
- [N/A] Update default config/theme in README (if applicable)
- [N/A] Update man page at lsd/doc/lsd.md (if applicable)
