### PR TITLE
Add more tests in color.rs

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -496,5 +496,29 @@ mod elem {
             .get_color(&test_theme()),
             Color::AnsiValue(184),
         );
+        assert_eq!(
+            Elem::BrokenSymLink.get_color(&test_theme()),
+            Color::AnsiValue(124)
+        );
+        assert_eq!(
+            Elem::Dir { uid: true }.get_color(&test_theme()),
+            Color::AnsiValue(33)
+        );
+        assert_eq!(
+            Elem::Dir { uid: false }.get_color(&test_theme()),
+            Color::AnsiValue(33)
+        );
+        assert_eq!(
+            Elem::BlockDevice.get_color(&test_theme()),
+            Color::AnsiValue(44)
+        );
+        assert_eq!(
+            Elem::CharDevice.get_color(&test_theme()),
+            Color::AnsiValue(172)
+        );
+        assert_eq!(
+            Elem::Special.get_color(&test_theme()),
+            Color::AnsiValue(44)
+        );
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -392,8 +392,9 @@ mod tests {
 #[cfg(test)]
 mod elem {
     use super::Elem;
-    use crate::theme::{color, color::ColorTheme};
-    use crossterm::style::Color;
+    use crate::{color::to_content_style, theme::color::{self, ColorTheme}};
+    use crossterm::style::{Attribute, Color, ContentStyle};
+    use lscolors::FontStyle;
 
     #[cfg(test)]
     fn test_theme() -> ColorTheme {
@@ -519,6 +520,30 @@ mod elem {
         assert_eq!(
             Elem::Special.get_color(&test_theme()),
             Color::AnsiValue(44)
+        );
+    }
+
+    #[test]
+    fn test_content_style() {
+        let mut custom_content_style = ContentStyle {
+                foreground_color: Some(Color::DarkRed),
+                background_color: Some(Color::AnsiValue(50)),
+                ..ContentStyle::default()
+            };
+        custom_content_style.attributes.set(Attribute::Bold);
+
+        assert_eq!(
+            to_content_style(&lscolors::Style::default()),
+            ContentStyle::default()
+        );
+        assert_eq!(
+            to_content_style(&lscolors::Style {
+                foreground: Some(lscolors::Color::Red),
+                background: Some(lscolors::Color::Fixed(50)),
+                font_style: FontStyle::bold(),
+                underline: Some(lscolors::Color::BrightBlue),
+            }),
+            custom_content_style
         );
     }
 }


### PR DESCRIPTION
Added more `assert_eq!` statements in `test_default_theme_color`, testing more file types
Added a test case for `color::to_content_style`
This PR is targeted at issue #46

------
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
