### PR TITLE
Update lscolors to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,10 +871,11 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lscolors"
-version = "0.16.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b209ec3976527806024406fe765474b9a1750a0ed4b8f0372364741f50e7b"
+checksum = "61183da5de8ba09a58e330d55e5ea796539d8443bd00fdeb863eac39724aa4ab"
 dependencies = [
+ "aho-corasick",
  "nu-ansi-term",
 ]
 
@@ -943,11 +944,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.49.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ chrono = { version = "0.4.19", features = ["unstable-locales"] }
 chrono-humanize = "0.2"
 # incompatible with v0.1.11
 unicode-width = "0.1.13"
-lscolors = "0.16.0"
+lscolors = "0.20.0"
 wild = "2.0"
 globset = "0.4.*"
 yaml-rust = "0.4.*"


### PR DESCRIPTION
<!--- PR Description --->
Update `lscolors` from 0.16.0 to 0.20.0.

- [0.20.0](https://github.com/sharkdp/lscolors/releases/tag/v0.20.0): Updated `crossterm` dependency
- [0.19.0](https://github.com/sharkdp/lscolors/releases/tag/v0.19.0): Fast extension matching
- [0.18.0](https://github.com/sharkdp/lscolors/releases/tag/v0.18.0): Add `owo-colors` as an ansi backend; make `fi=0` disable fallback to no
- [0.17.0](https://github.com/sharkdp/lscolors/releases/tag/v0.17.0): Add an option to style any string without path verification; update `nu-ansi-term` to latest release 0.50.0

I confirmed that `cargo test` still passes.

---
#### TODO

- [x] Use `cargo fmt` **N/A, no Rust code changes**
- [x] Add necessary tests **N/A, no Rust code changes**
- [ ] Update default config/theme in README (if applicable) **N/A**
- [ ] Update man page at lsd/doc/lsd.md (if applicable) **N/A**
