### PR TITLE
Bump uzers from 0.11.3 to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,9 +1572,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uzers"
-version = "0.11.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+checksum = "0b8275fb1afee25b4111d2dc8b5c505dbbc4afd0b990cb96deb2d88bff8be18d"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ xdg = "2.5"
 git2 = { version = "0.20", optional = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-users = { version = "0.11.3", package = "uzers" }
+users = { version = "0.12", package = "uzers" }
 xattr = "1"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
<!--- PR Description --->

Bump uzers from 0.11.3 to 0.12

The changelog does not actually list any changes that should be breaking, and all tests pass

v0.12.0:
https://github.com/rustadopt/uzers-rs/blob/main/CHANGELOG.md#0120---2024-04-23

v0.12.1:
https://github.com/rustadopt/uzers-rs/blob/main/CHANGELOG.md#0121---2024-08-03

v0.12.2:
https://github.com/rustadopt/uzers-rs/blob/main/CHANGELOG.md#0122---2025-12-16



---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Update README (if applicable)
- [x] Update config sample file in `doc/samples` (if applicable)
- [x] Update icon sample file in `doc/samples` (if applicable)
- [x] Update color sample file in `doc/samples` (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
