### PR TITLE
Bump xdg from 2.5 to 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 url = "2.5.4"
 vsort = "0.2"
-xdg = "2.5"
+xdg = "3"
 
 [target."cfg(not(all(windows, target_arch = \"x86\", target_env = \"gnu\")))".dependencies]
 # if ssl feature is enabled compilation will fail on arm-unknown-linux-gnueabihf and i686-pc-windows-gnu

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -180,9 +180,7 @@ impl Config {
             dirs::home_dir().map(|h| h.join(".config")),
             dirs::config_dir(),
             #[cfg(not(windows))]
-            BaseDirectories::with_prefix("")
-                .ok()
-                .map(|p| p.get_config_home()),
+            BaseDirectories::with_prefix("").get_config_home(),
         ]
         .iter()
         .filter_map(|p| p.as_ref().map(|p| p.join("lsd")))


### PR DESCRIPTION
<!--- PR Description --->
The only change required is that the `BaseDirectories` methods now always returns a `BaseDirectories` object and there is no wrapping with `Result`

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Update README (if applicable)
- [x] Update config sample file in `doc/samples` (if applicable)
- [x] Update icon sample file in `doc/samples` (if applicable)
- [x] Update color sample file in `doc/samples` (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
