### PR TITLE
Use POSIX symlink arrow for classic mode

### DIFF
--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -27,7 +27,7 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 : Do not list implied **.** and **..**
 
 `--classic`
-: Enable classic mode (no colours or icons)
+: Enable classic mode (POSIX symlink arrows and no colours or icons)
 
 `-L`, `--dereference`
 : When showing file information for a symbolic link, show information for the file the link references rather than for the link itself

--- a/doc/samples/config-sample.yaml
+++ b/doc/samples/config-sample.yaml
@@ -2,7 +2,8 @@
 # == Classic ==
 # This is a shorthand to override some of the options to be backwards compatible
 # with `ls`. It affects the "color"->"when", "sorting"->"dir-grouping", "date"
-# and "icons"->"when" options.
+# and "icons"->"when" options. It will also use POSIX symlink arrows when the
+# symlink-arrow configuration is left unset.
 # Possible values: false, true
 classic: false
 

--- a/src/flags/symlink_arrow.rs
+++ b/src/flags/symlink_arrow.rs
@@ -8,22 +8,35 @@ use crate::config_file::Config;
 pub struct SymlinkArrow(String);
 
 impl Configurable<Self> for SymlinkArrow {
-    /// `SymlinkArrow` can not be configured by [Cli]
+    /// `SymlinkArrow` can be indirectly configured by [Cli] when the classic option is used.
     ///
-    /// Return `None`
-    fn from_cli(_: &Cli) -> Option<Self> {
-        None
+    /// If classic is used, returns `->` in a [Some];
+    /// otherwise this returns [None].
+    fn from_cli(cli: &Cli) -> Option<Self> {
+        if cli.classic {
+            Some(SymlinkArrow("->".to_string()))
+        } else {
+            None
+        }
     }
+
     /// Get a potential `SymlinkArrow` value from a [Config].
     ///
-    /// If the `Config::symlink-arrow` has value,
+    /// If the `Config::symlink_arrow` has value,
     /// returns its value as the value of the `SymlinkArrow`, in a [Some].
-    /// Otherwise this returns [None].
+    /// If no arrow is configured and classic is enabled,
+    /// returns `->` in a [Some]; otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        config
-            .symlink_arrow
-            .as_ref()
-            .map(|arrow| SymlinkArrow(arrow.to_string()))
+        match config.symlink_arrow.as_ref() {
+            Some(arrow) => Some(SymlinkArrow(arrow.to_string())),
+            None => {
+                if config.classic == Some(true) {
+                    Some(SymlinkArrow("->".to_string()))
+                } else {
+                    None
+                }
+            }
+        }
     }
 }
 
@@ -62,10 +75,42 @@ mod test {
     }
 
     #[test]
+    fn test_symlink_arrow_config_none_classic() {
+        let mut c = Config::with_none();
+        c.classic = Some(true);
+        assert_eq!(
+            Some(SymlinkArrow(String::from("->"))),
+            SymlinkArrow::from_config(&c)
+        );
+    }
+
+    #[test]
+    fn test_symlink_arrow_config_some_classic() {
+        let mut c = Config::with_none();
+        c.classic = Some(true);
+        c.symlink_arrow = Some("↹".into());
+        // the configured arrow gets precedence over the classic arrow
+        assert_eq!(
+            Some(SymlinkArrow(String::from("\u{21B9}"))),
+            SymlinkArrow::from_config(&c)
+        );
+    }
+
+    #[test]
     fn test_symlink_arrow_from_args_none() {
         let argv = ["lsd"];
         let cli = Cli::try_parse_from(argv).unwrap();
         assert_eq!(None, SymlinkArrow::from_cli(&cli));
+    }
+
+    #[test]
+    fn test_symlink_arrow_from_args_classic() {
+        let argv = ["lsd", "--classic"];
+        let cli = Cli::try_parse_from(argv).unwrap();
+        assert_eq!(
+            Some(SymlinkArrow("->".to_string())),
+            SymlinkArrow::from_cli(&cli)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Address #1204. Always use `->` for symlinks when lsd is invoked with --classic CLI option; and when classic is enabled in config unless symlink-arrow is set, which gets priority.

#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Update README (if applicable)
- [x] Update config sample file in `doc/samples` (if applicable)
- [x] Update icon sample file in `doc/samples` (if applicable)
- [x] Update color sample file in `doc/samples` (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)
